### PR TITLE
[12.0] add calendar base booking

### DIFF
--- a/calendar_base_booking/__init__.py
+++ b/calendar_base_booking/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/calendar_base_booking/__manifest__.py
+++ b/calendar_base_booking/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "Calendar Base Booking",
+    "summary": "Base module for adding booking feature",
+    "version": "12.0.0.0.0",
+    "development_status": "Alpha",
+    "category": "Calendar",
+    "website": "https://github.com/OCA/calendar",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["sebastienbeau"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "external_dependencies": {"python": [], "bin": []},
+    "depends": ["calendar"],
+    "data": [],
+    "demo": [],
+    "qweb": [],
+}

--- a/calendar_base_booking/models/__init__.py
+++ b/calendar_base_booking/models/__init__.py
@@ -1,0 +1,2 @@
+from . import calendar
+from . import bookable_mixin

--- a/calendar_base_booking/models/bookable_mixin.py
+++ b/calendar_base_booking/models/bookable_mixin.py
@@ -1,0 +1,127 @@
+# Copyright 2020 Akretion (http://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from collections import defaultdict
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields, models
+from odoo.osv import expression
+
+# Concept
+# open_slot is the range of time where the ressource can be book
+# available_slot is the range of time where the ressource is available for booking
+# booked_slot is a slot already booked
+# bookable_slot is a slot (with a size if slot_duration) that fit into
+# an available slot
+
+
+class BookableMixin(models.AbstractModel):
+    _name = "bookable.mixin"
+    _description = "Bookable Mixin"
+
+    slot_duration = fields.Float()
+    slot_capacity = fields.Integer()
+
+    def _get_slot_duration(self):
+        return self.slot_duration
+
+    def _get_slot_capacity(self):
+        return self.slot_capacity
+
+    def _get_booked_slot(self, start, stop):
+        domain = self._get_domain(start, stop)
+        return self.env["calendar.event"].search(
+            expression.AND([domain, [("booking_type", "=", "booked")]])
+        )
+
+    def _build_timeline_load(self, start, stop):
+        timeline = defaultdict(int)
+        timeline.update({start: 0, stop: 0})
+        for booked_slot in self._get_booked_slot(start, stop):
+            if booked_slot.start < start:
+                timeline[start] += 1
+            else:
+                timeline[booked_slot.start] += 1
+            if booked_slot.stop < stop:
+                timeline[booked_slot.stop] -= 1
+
+        timeline = list(timeline.items())
+        timeline.sort()
+        return timeline
+
+    def _get_available_slot(self, start, stop):
+        load_timeline = self._build_timeline_load(start, stop)
+
+        load = 0
+        slots = []
+        slot = None
+        capacity = self._get_slot_capacity()
+
+        for dt, load_delta in load_timeline:
+            load += load_delta
+            if not slot and load < capacity:
+                slot = [dt, None]
+                slots.append(slot)
+            elif slot and load >= capacity:
+                slot = None
+            else:
+                slot[1] = dt
+        return slots
+
+    def _prepare_bookable_slot(self, open_slot, start, stop):
+        # If need you can inject extra information from the open_slot
+        return {"start": start, "stop": stop}
+
+    def _build_bookable_slot(self, open_slot, start, stop):
+        bookable_slots = []
+        # now we have to care about datetime vs string
+        delta = self._get_slot_duration()
+        while True:
+            slot_stop = start + relativedelta(minutes=delta)
+            if slot_stop > stop:
+                break
+            bookable_slots.append(
+                self._prepare_bookable_slot(open_slot, start, slot_stop)
+            )
+            start += relativedelta(minutes=delta)
+        return bookable_slots
+
+    def get_bookable_slot(self, start, stop):
+        start = fields.Datetime.to_datetime(start)
+        stop = fields.Datetime.to_datetime(stop)
+
+        slots = []
+        domain = self._get_domain(start, stop)
+        available_domain = expression.AND([domain, [("booking_type", "=", "bookable")]])
+        for open_slot in self.env["calendar.event"].search(
+            available_domain, order="start_date"
+        ):
+            for slot_start, slot_stop in self._get_available_slot(
+                max(open_slot.start, start), min(open_slot.stop, stop)
+            ):
+                slots += self._build_bookable_slot(open_slot, slot_start, slot_stop)
+        return slots
+
+    def _get_domain(self, start, stop):
+        # be carefull we need to search for every slot (bookable and booked)
+        # that exist in the range start/stop
+        # This mean that we need the slot
+        # - started before and finishing in the range
+        # - started and finished in the range
+        # - started in the range and fisnish after
+        # In an other expression it's
+        # - all slot that start in the range
+        # - all slot that finish in the range
+        return [
+            ("res_model", "=", self._name),
+            ("res_id", "=", self.id),
+            "|",
+            "&",
+            ("start", ">=", start),
+            ("start", "<", stop),
+            "&",
+            ("stop", ">", start),
+            ("stop", "<=", stop),
+        ]

--- a/calendar_base_booking/models/calendar.py
+++ b/calendar_base_booking/models/calendar.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Akretion (http://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class CalendarEvent(models.Model):
+    _inherit = "calendar.event"
+
+    booking_type = fields.Selection(
+        [
+            ("bookable", "Bookable"),
+            ("not_bookable", "Not bookable"),
+            ("booked", "Booked"),
+        ]
+    )

--- a/calendar_base_booking/models/calendar.py
+++ b/calendar_base_booking/models/calendar.py
@@ -2,7 +2,7 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class CalendarEvent(models.Model):
@@ -15,3 +15,12 @@ class CalendarEvent(models.Model):
             ("booked", "Booked"),
         ]
     )
+
+    @api.onchange("booking_type")
+    def on_booking_type_change(self):
+        if self.booking_type in ["bookable", "not_bookable"]:
+            self.name = dict(
+                self._fields["booking_type"]._description_selection(self.env)
+                )[self.booking_type]
+        else:
+            self.name = ""

--- a/calendar_base_booking/tests/__init__.py
+++ b/calendar_base_booking/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_bookable

--- a/calendar_base_booking/tests/fake_model_loader.py
+++ b/calendar_base_booking/tests/fake_model_loader.py
@@ -1,0 +1,73 @@
+import mock
+
+from odoo import models
+from odoo.tools import OrderedSet
+
+
+class FakePackage(object):  # noqa
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeModelLoader(object):
+
+    _original_registry = None
+    _original_module2modules = None
+    _module_name = None
+
+    @classmethod
+    def _backup_registry(cls, env, module_name):
+        cls.env = env
+        cls._module_name = module_name
+        cls._original_registry = {}
+        for model_name, model in env.registry.models.items():
+            cls._original_registry[model_name] = {
+                "base": model.__bases__,
+                "_fields": model._fields.copy(),
+                "_inherit_children": OrderedSet(model._inherit_children._map.keys()),
+                "_inherits_children": set(model._inherits_children),
+            }
+        cls._original_module2modules = list(
+            models.MetaModel.module_to_models[module_name]
+        )
+
+    @classmethod
+    def _update_registry(cls, odoo_models):
+        # This can append if you have test that reuse the abstract class from an other
+        # module. In that case the "from . import models" will not reload the file
+        # and so the class will be not in the module_to_models
+        module_to_models = models.MetaModel.module_to_models[cls._module_name]
+        for model in odoo_models:
+            if model not in module_to_models:
+                module_to_models.append(model)
+        with mock.patch.object(cls.env.cr, "commit"):
+            model_names = cls.env.registry.load(
+                cls.env.cr, FakePackage(cls._module_name)
+            )
+            cls.env.registry.setup_models(cls.env.cr)
+            cls.env.registry.init_models(
+                cls.env.cr, model_names, {"module": cls._module_name}
+            )
+
+    @classmethod
+    def _restore_registry(cls):
+        for key in cls._original_registry:
+            ori = cls._original_registry[key]
+            model = cls.env.registry[key]
+            model.__bases__ = ori["base"]
+            model._inherit_children = ori["_inherit_children"]
+            model._inherits_children = ori["_inherits_children"]
+            for field in model._fields:
+                if field not in ori["_fields"]:
+                    if hasattr(model, field):
+                        delattr(model, field)
+            model._fields = ori["_fields"]
+        for key, _model in cls.env.registry.models.items():
+            if key not in cls._original_registry:
+                del cls.env.registry.models[key]
+
+        models.MetaModel.module_to_models[
+            cls._module_name
+        ] = cls._original_module2modules
+        cls.env.registry.model_cache.clear()
+        cls.env.registry.load(cls.env.cr, FakePackage(cls._module_name))

--- a/calendar_base_booking/tests/models.py
+++ b/calendar_base_booking/tests/models.py
@@ -1,0 +1,11 @@
+# Copyright 2020 Akretion (http://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = ["bookable.mixin", "res.partner"]
+    _name = "res.partner"

--- a/calendar_base_booking/tests/test_bookable.py
+++ b/calendar_base_booking/tests/test_bookable.py
@@ -1,0 +1,98 @@
+# Copyright 2020 Akretion (http://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields
+from odoo.tests import SavepointCase
+
+from .fake_model_loader import FakeModelLoader
+
+CALENDAR = [
+    ("2020-04-06 08:00:00", "2020-04-06 12:00:00"),
+    ("2020-04-06 14:00:00", "2020-04-06 18:00:00"),
+    ("2020-04-07 08:00:00", "2020-04-07 12:00:00"),
+    ("2020-04-07 14:00:00", "2020-04-07 18:00:00"),
+]
+
+# le get_available_time_slot est appeler sur quel object
+# warehouse, personne (coiffeur), matériel (ressource)
+# plusieurs chose en même temps? (intersection de calendrier ou // de calendrier)
+
+
+class TestBooking(SavepointCase, FakeModelLoader):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._backup_registry(cls.env, "calendar_base_booking")
+        from .models import ResPartner
+
+        cls._update_registry([ResPartner])
+        cls.partner = cls.env["res.partner"].search([], limit=1)
+        cls.partner.slot_capacity = 1
+        cls.partner.slot_duration = 90
+        for event in CALENDAR:
+            cls.env["calendar.event"].create(
+                {
+                    "name": "Foo",
+                    "start": event[0],
+                    "stop": event[1],
+                    "booking_type": "bookable",
+                    "res_model_id": cls.env.ref("base.model_res_partner").id,
+                    "res_id": cls.partner.id,
+                }
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls._restore_registry()
+
+    def _convert_to_string(self, slots):
+        for slot in slots:
+            for key in ["start", "stop"]:
+                slot[key] = fields.Datetime.to_string(slot[key])
+        return slots
+
+    def _get_slot(self, start, stop):
+        return self._convert_to_string(self.partner.get_bookable_slot(start, stop))
+
+    def test_get_available_time_slot_case_1(self):
+        slots = self._get_slot("2020-04-06 08:00:00", "2020-04-06 18:00:00")
+        expected = [
+            {"start": "2020-04-06 08:00:00", "stop": "2020-04-06 09:30:00"},
+            {"start": "2020-04-06 09:30:00", "stop": "2020-04-06 11:00:00"},
+            {"start": "2020-04-06 14:00:00", "stop": "2020-04-06 15:30:00"},
+            {"start": "2020-04-06 15:30:00", "stop": "2020-04-06 17:00:00"},
+        ]
+        self.assertEqual(slots, expected)
+
+    def test_get_available_time_slot_case_2(self):
+        slots = self._get_slot("2020-04-06 09:00:00", "2020-04-06 17:00:00")
+        expected = [
+            {"start": "2020-04-06 09:00:00", "stop": "2020-04-06 10:30:00"},
+            {"start": "2020-04-06 10:30:00", "stop": "2020-04-06 12:00:00"},
+            {"start": "2020-04-06 14:00:00", "stop": "2020-04-06 15:30:00"},
+            {"start": "2020-04-06 15:30:00", "stop": "2020-04-06 17:00:00"},
+        ]
+        self.assertEqual(slots, expected)
+
+    def test_get_available_time_slot_case_3(self):
+        slots = self._get_slot("2020-04-06 09:00:00", "2020-04-06 15:00:00")
+        expected = [
+            {"start": "2020-04-06 09:00:00", "stop": "2020-04-06 10:30:00"},
+            {"start": "2020-04-06 10:30:00", "stop": "2020-04-06 12:00:00"},
+        ]
+        self.assertEqual(slots, expected)
+
+    def test_get_available_time_slot_case_4(self):
+        slots = self._get_slot("2020-04-06 11:00:00", "2020-04-06 18:00:00")
+        expected = [
+            {"start": "2020-04-06 14:00:00", "stop": "2020-04-06 15:30:00"},
+            {"start": "2020-04-06 15:30:00", "stop": "2020-04-06 17:00:00"},
+        ]
+        self.assertEqual(slots, expected)
+
+    def test_get_available_time_slot_case_5(self):
+        slots = self._get_slot("2020-04-06 11:00:00", "2020-04-06 15:00:00")
+        expected = []
+        self.assertEqual(slots, expected)


### PR DESCRIPTION
Work in progress
The aim of this module is to add an abstract mixing for managing booking.
This can be added on every odoo model.
We build this dependency in order to had the feature of booking a datetime for retrieving the delivery into a physical shop (for Shopinvader), more module to come.