### PR TITLE
[FIX] resource_calendar: ignore past or unconfirmed bookings when updating calendars

### DIFF
--- a/resource_booking/models/resource_calendar.py
+++ b/resource_booking/models/resource_calendar.py
@@ -19,6 +19,8 @@ class ResourceCalendar(models.Model):
         """Scheduled bookings must have no conflicts."""
         bookings = self.env["resource.booking"].search(
             [
+                ("state", "=", "confirmed"),
+                ("stop", ">=", fields.Datetime.now()),
                 "|",
                 ("combination_id.forced_calendar_id", "in", self.ids),
                 ("combination_id.resource_ids.calendar_id", "in", self.ids),


### PR DESCRIPTION
Without this patch, users couldn't change a calendar schedule if there were past or unconfirmed bookings that wouldn't fit in it.

Excluding those bookings from the check fixes the situation.

We also check that, to confirm a booking, it must fit in the calendar (because now it can happen that, in the time that has passed since the booking was scheduled until it is confirmed, the calendar changes).


@Tecnativa TT29509