### PR TITLE
[FIX] resource_booking: always notify in resource TZ

### DIFF
--- a/resource_booking/models/calendar_event.py
+++ b/resource_booking/models/calendar_event.py
@@ -51,3 +51,13 @@ class CalendarEvent(models.Model):
                 rescheduled -= new
         rescheduled._validate_booking_modifications()
         return result
+
+    def get_interval(self, interval, tz=None):
+        """Autofix tz from related resource booking.
+
+        This function is called to render calendar.event notification mails.
+        Any notification related to a resource.booking must be emitted in the
+        same TZ as the resource.booking. Otherwise it's confusing to the user.
+        """
+        tz = self.resource_booking_ids.type_id.resource_calendar_id.tz or tz
+        return super().get_interval(interval=interval, tz=tz)


### PR DESCRIPTION
The notifications emitted to the resource booking requester must always be in the same TZ as the resource booking itself.

For example, if you book one hotel room in the other side of the world, a notification in your own TZ is confusing.

Besides, res.partner created from website_sale are created with `tz=False`, making it even more confusing.

@Tecnativa TT30331