### PR TITLE
[12.0][FIX] resource_booking: Limit constraint only to future bookings

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -271,7 +271,13 @@ class ResourceBooking(models.Model):
             )
         # Ensure all bookings fit in their type and resources calendars
         unfitting_bookings = has_meeting
+        now = fields.Datetime.now()
         for booking in has_meeting:
+            # Ignore if the event already happened
+            already_happened = booking.stop and booking.stop < now
+            if already_happened:
+                unfitting_bookings -= booking
+                continue
             meeting_dates = tuple(
                 fields.Datetime.context_timestamp(self, booking[field])
                 for field in ("start", "stop")


### PR DESCRIPTION
The constraint that checks the schedule of a resource booking is currently being applied to **all the bookings**, including past ones.
As the resource combination or associated calendars might change regularly and trigger a recomputation of this, such change might take a very long time.
Plus, the calendar restrictions might change, trigger a recompute of the constraint and detect bookings that can't be assigned, which makes no sense when they already happened. 

This applies it only to future bookings, ignoring past ones.

@Tecnativa
TT30478

ping @Yajo @sergio-teruel 