### PR TITLE
[IMP] resource_booking: simplified time format

### DIFF
--- a/resource_booking/templates/portal.xml
+++ b/resource_booking/templates/portal.xml
@@ -17,8 +17,10 @@
     - weekday_names: dict of mappings between weekday numbers and names, where MON=1
      -->
     <template id="scheduling_calendar" name="Resource Booking Calendar">
+        <t t-set="confirm_url" t-value="booking.get_portal_url(suffix='/confirm')" />
+        <t t-set="date_format" t-value="res_lang.date_format" />
+        <t t-set="time_format" t-value="res_lang.time_format.replace(':%S', '')" />
         <div class="o_booking_calendar">
-            <t t-set="confirm_url" t-value="booking.get_portal_url(suffix='/confirm')" />
 
             <div class="alert alert-danger" t-if="not slots">
                 No free slots found this month.
@@ -71,7 +73,7 @@
                                             <div class="dropdown-menu slots-dropdown" t-attf-aria-labelledby="dropdown-trigger-#{day.isoformat()}">
                                                 <t t-foreach="slots[day]" t-as="slot">
                                                     <!-- Hour item to open confirmation -->
-                                                    <button class="dropdown-item" type="button" data-toggle="modal" t-attf-data-target="#modal-confirm-#{int(slot.timestamp())}" t-esc="slot.strftime(res_lang.time_format)" />
+                                                    <button class="dropdown-item" type="button" data-toggle="modal" t-attf-data-target="#modal-confirm-#{int(slot.timestamp())}" t-esc="slot.strftime(time_format)" />
                                                 </t>
                                             </div>
                                         </div>
@@ -111,8 +113,8 @@
                                     <ul>
                                         <li>
                                             Start:
-                                            <strong t-esc="slot.strftime(res_lang.date_format)"></strong>
-                                            <strong t-esc="slot.strftime(res_lang.time_format)"></strong>
+                                            <strong t-esc="slot.strftime(date_format)"></strong>
+                                            <strong t-esc="slot.strftime(time_format)"></strong>
                                         </li>
                                         <li>
                                             Duration:

--- a/resource_booking/tests/test_portal.py
+++ b/resource_booking/tests/test_portal.py
@@ -138,11 +138,11 @@ class PortalCase(HttpCase):
         slot = datetime(2021, 3, 1, 10).timestamp()
         selector_10am = (
             "#dropdown-trigger-2021-03-01 "
-            "+ .slots-dropdown .dropdown-item:contains('10:00:00')"
+            "+ .slots-dropdown .dropdown-item:contains('10:00')"
         )
         selector_1030am = (
             "#dropdown-trigger-2021-03-01 "
-            "+ .slots-dropdown .dropdown-item:contains('10:30:00')"
+            "+ .slots-dropdown .dropdown-item:contains('10:30')"
         )
         self.assertTrue(public_page.cssselect(selector_10am))
         self.assertTrue(public_page.cssselect(selector_1030am))


### PR DESCRIPTION
It's very unlikely that you need to book resources in a seconds-based precision.

This simplifies portal UI. Still, declared as a variable in case you need some customizations downstream.

@Tecnativa TT31063