### PR TITLE
[IMP+FIX] resource_booking: duration, location, involves me, hr_holidays_public

### DIFF
--- a/resource_booking/__manifest__.py
+++ b/resource_booking/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Resource booking",
     "summary": "Manage appointments and resource booking",
-    "version": "13.0.1.0.0",
+    "version": "13.0.2.0.0",
     "development_status": "Beta",
     "category": "Appointments",
     "website": "https://github.com/OCA/calendar",

--- a/resource_booking/controllers/portal.py
+++ b/resource_booking/controllers/portal.py
@@ -49,7 +49,7 @@ class CustomerPortal(portal.CustomerPortal):
     )
     def portal_my_bookings(self, page=1, **kwargs):
         """List bookings that I can access."""
-        Booking = request.env["resource.booking"]
+        Booking = request.env["resource.booking"].with_context(using_portal=True)
         values = self._prepare_portal_layout_values()
         pager = portal.pager(
             url="/my/bookings",

--- a/resource_booking/migrations/13.0.2.0.0/pre-migrate.py
+++ b/resource_booking/migrations/13.0.2.0.0/pre-migrate.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+def remove_start_stop_together_constraint(cr):
+    """Remove old unnecessary constraint.
+
+    This one is no longer needed because `stop` is now computed and readonly,
+    so it will always have or not have value automatically.
+    """
+    openupgrade.logged_query(
+        cr,
+        """
+            ALTER TABLE resource_booking
+            DROP CONSTRAINT IF EXISTS resource_booking_start_stop_together
+        """,
+    )
+
+
+def fill_resource_booking_duration(env):
+    """Pre-create and pre-fill resource.booking duration."""
+    openupgrade.add_fields(
+        env,
+        [
+            (
+                "duration",
+                "resource.booking",
+                "resource_booking",
+                "float",
+                None,
+                "resource_booking",
+                None,
+            )
+        ],
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE resource_booking rb
+            SET duration = COALESCE(
+                -- See https://stackoverflow.com/a/952600/1468388
+                EXTRACT(EPOCH FROM rb.stop - rb.start) / 3600,
+                rbt.duration
+            )
+            FROM resource_booking_type rbt
+            WHERE rb.type_id = rbt.id
+        """,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    remove_start_stop_together_constraint(env.cr)
+    fill_resource_booking_duration(env)

--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -446,7 +446,10 @@ class ResourceBooking(models.Model):
             booking_id = self.id or self._origin.id or -1
         except AttributeError:
             booking_id = -1
-        booking = self.with_context(analyzing_booking=booking_id)
+        # Detached compatibility with hr_holidays_public
+        booking = self.with_context(
+            analyzing_booking=booking_id, exclude_public_holidays=True
+        )
         # RBT calendar uses no resources to restrict bookings
         result = booking.type_id.resource_calendar_id._work_intervals(start_dt, end_dt)
         # Restrict with the chosen combination, or to at least one of the

--- a/resource_booking/models/resource_booking_combination.py
+++ b/resource_booking/models/resource_booking_combination.py
@@ -72,7 +72,8 @@ class ResourceBookingCombination(models.Model):
         """Get available intervals for this booking combination."""
         base = Intervals([(start_dt, end_dt, self)])
         result = Intervals([])
-        for combination in self:
+        # Detached compatibility with hr_holidays_public
+        for combination in self.with_context(exclude_public_holidays=True):
             combination_intervals = base
             for res in combination.resource_ids:
                 if not combination_intervals:

--- a/resource_booking/models/resource_booking_type.py
+++ b/resource_booking/models/resource_booking_type.py
@@ -58,7 +58,10 @@ class ResourceBookingType(models.Model):
     duration = fields.Float(
         required=True,
         default=0.5,  # 30 minutes
-        help="Establish each interval's duration.",
+        help=(
+            "Interval offered to start each resource booking. "
+            "Also used as booking default duration."
+        ),
     )
     location = fields.Char()
     modifications_deadline = fields.Float(

--- a/resource_booking/readme/CONFIGURE.rst
+++ b/resource_booking/readme/CONFIGURE.rst
@@ -16,7 +16,9 @@ To configure one booking type:
 #. Go to *Resource Bookings > Types*.
 #. Create one.
 #. Give it a *name*.
-#. Set the *Duration*, to know the time assigned to each calendar slot.
+#. Set the *Duration*, to know the time assigned to each calendar slot. It will
+   also be the default duration for each booking, although that can be changed
+   later if necessary.
 #. Set the *Modifications Deadline*, to forbid non-managers to alter dates of
    a booking when it's too late.
 #. Choose one *Availability Calendar*. No bookings will exist outside of it.

--- a/resource_booking/readme/USAGE.rst
+++ b/resource_booking/readme/USAGE.rst
@@ -33,5 +33,7 @@ To invite someone to book a resource combination from the portal:
 #. Pick one *Resources combination*, if you want that the requester is assigned
    to that combination. Otherwise, leave it empty, and some free combination
    will be assigned automatically when the requester picks a free slot.
+#. Choose the *duration*, in case it is different from the one specified in the
+   resource booking type.
 #. Click on *Share > Send*.
 #. The requester will receive an email to select a calendar slot from his portal.

--- a/resource_booking/readme/USAGE.rst
+++ b/resource_booking/readme/USAGE.rst
@@ -19,8 +19,8 @@ To book some resources:
 #. Click on *Booking Count*.
 #. Click on a free slot.
 #. Fill the *Requester*, which may or not be yourself.
-#. Pick one *Resources combination*, in case the one assigned automatically
-   isn't the one you want.
+#. Uncheck *Auto assign* and pick one *Resources combination*, in case the one
+   assigned automatically isn't the one you want.
 
 To invite someone to book a resource combination from the portal:
 
@@ -30,9 +30,10 @@ To invite someone to book a resource combination from the portal:
 #. Click on the list view icon.
 #. Click on *Create*.
 #. Fill the *Requester*.
-#. Pick one *Resources combination*, if you want that the requester is assigned
-   to that combination. Otherwise, leave it empty, and some free combination
-   will be assigned automatically when the requester picks a free slot.
+#. Uncheck *Auto assign* and pick one *Resources combination*, if you want that
+   the requester is assigned to that combination. Otherwise, leave it empty,
+   and some free combination will be assigned automatically when the requester
+   picks a free slot.
 #. Choose the *duration*, in case it is different from the one specified in the
    resource booking type.
 #. Click on *Share > Send*.

--- a/resource_booking/templates/portal.xml
+++ b/resource_booking/templates/portal.xml
@@ -187,7 +187,7 @@
                                         <li>
                                             Duration:
                                             <strong
-                                                t-field="booking.type_id.duration"
+                                                t-field="booking.duration"
                                                 t-options='{"widget": "float_time"}'
                                             />
                                         </li>

--- a/resource_booking/templates/portal.xml
+++ b/resource_booking/templates/portal.xml
@@ -278,8 +278,7 @@
                     <tr>
                         <td>
                             <a t-att-href="booking.get_portal_url()">
-                                #
-                                <span t-field="booking.id" />
+                                <span t-field="booking.display_name" />
                             </a>
                         </td>
                         <td>
@@ -306,8 +305,8 @@
         <div class="row no-gutters">
             <div class="col-md">
                 <h5 class="mb-1 mb-md-0">
-                    Booking #
-                    <span t-field="booking_sudo.id" />
+                    Booking
+                    <span t-field="booking_sudo.display_name" />
                 </h5>
             </div>
             <div class="col-md text-md-right">

--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -468,3 +468,35 @@ class BackendCase(SavepointCase):
         rb.action_unschedule()
         self.assertFalse(rb.meeting_id)
         self.assertEqual(rb.location, "Office 3")
+
+    def test_resource_booking_display_name(self):
+        # Pending booking with no name
+        rb = self.env["resource.booking"].create(
+            {"partner_id": self.partner.id, "type_id": self.rbt.id}
+        )
+        self.assertEqual(rb.display_name, "some customer - Test resource booking type")
+        self.assertEqual(
+            rb.with_context(using_portal=True).display_name, "# %d" % rb.id
+        )
+        # Pending booking with name
+        rb.name = "changed"
+        self.assertEqual(rb.display_name, "changed")
+        self.assertEqual(
+            rb.with_context(using_portal=True).display_name, "# %d - changed" % rb.id
+        )
+        # Scheduled booking with name
+        rb.start = "2021-03-01 08:00:00"
+        self.assertEqual(rb.display_name, "changed")
+        self.assertEqual(
+            rb.with_context(using_portal=True).display_name, "# %d - changed" % rb.id
+        )
+        # Scheduled booking with no name
+        rb.name = False
+        self.assertEqual(
+            rb.display_name,
+            "some customer - Test resource booking type "
+            "- 03/01/2021 at (08:00:00 To 08:30:00) (UTC)",
+        )
+        self.assertEqual(
+            rb.with_context(using_portal=True).display_name, "# %d" % rb.id
+        )

--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -190,7 +190,7 @@
                 <filter
                     name="is_mine"
                     string="Involving me"
-                    domain="[('involves_me', '=', True)]"
+                    domain="['|', '|', ('partner_id.user_ids', '=', uid), ('meeting_id.attendee_ids.partner_id.user_ids', '=', uid), ('combination_id.resource_ids.user_id', '=', uid)]"
                 />
                 <filter
                     name="is_pending"

--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -129,10 +129,16 @@
                         <group name="booking">
                             <field name="partner_id" />
                             <field name="type_id" />
-                            <field
-                                name="combination_id"
-                                attrs="{'required': [('start', '!=', False)]}"
-                            />
+                            <label for="combination_id" />
+                            <div>
+                                <field name="combination_auto_assign" />
+                                <label for="combination_auto_assign" />
+                                <field
+                                    name="combination_id"
+                                    class="oe_inline"
+                                    attrs="{'required': [('start', '!=', False)], 'readonly': [('combination_auto_assign', '=', True)]}"
+                                />
+                            </div>
                             <field name="categ_ids" widget="many2many_tags" />
                         </group>
                         <group name="meeting" string="Meeting">
@@ -158,6 +164,7 @@
                                 class="oe_inline"
                             />
                             <field name="stop" />
+                            <field name="location" />
                         </group>
                     </group>
                 </sheet>

--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -10,7 +10,7 @@
             <calendar
                 string="Bookings"
                 date_start="start"
-                date_stop="stop"
+                date_delay="duration"
                 quick_add="false"
                 color="combination_id"
             >
@@ -136,7 +136,11 @@
                             <field name="categ_ids" widget="many2many_tags" />
                         </group>
                         <group name="meeting" string="Meeting">
-                            <field name="meeting_id" groups="base.group_no_one" />
+                            <field
+                                name="meeting_id"
+                                groups="base.group_no_one"
+                                readonly="1"
+                            />
                             <field name="is_overdue" invisible="1" />
                             <field name="is_modifiable" invisible="1" />
                             <div
@@ -147,14 +151,13 @@
                             >
                                 This booking exceeded its modifications deadline.
                             </div>
+                            <field name="start" />
                             <field
-                                name="start"
-                                attrs="{'required': [('stop', '!=', False)]}"
+                                name="duration"
+                                widget="float_time"
+                                class="oe_inline"
                             />
-                            <field
-                                name="stop"
-                                attrs="{'required': [('start', '!=', False)]}"
-                            />
+                            <field name="stop" />
                         </group>
                     </group>
                 </sheet>

--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -125,6 +125,11 @@
                             <span>Preview</span>
                         </button>
                     </div>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Resource Booking Name" />
+                        </h1>
+                    </div>
                     <group name="main">
                         <group name="booking">
                             <field name="partner_id" />


### PR DESCRIPTION
This PR includes several improvements or fixes for the `resource_booking` module:

##  [IMP] resource_booking: use duration field instead of stop 

From now on, `resource.booking.type` duration represents the default duration that will be applied to new `resource.booking` of that type, instead of the hardcoded duration for every new booking.

This means that you can create a new booking in pending state and define a custom duration before sending the portal link to customer.

Thus, the available schedule slots in portal will be based on the type duration, whereas only those that have enough time left to complete the booking duration will be displayed.

![image](https://user-images.githubusercontent.com/973709/126973764-32d339c8-64c4-495f-8b14-f52747a0c69f.png)


##  [IMP] resource_booking: configurable auto-assigned combination and location

Thanks to this patch, you will be able to more predictably block the chosen resource combination, with the added checkbox.

Also, the location field is propagated to `resource.booking` records, and synced from there to `calendar.event` if needed. This way, you can alter the location before sending the portal invitation.

![image](https://user-images.githubusercontent.com/973709/126974005-e4e74578-5785-4ecf-843e-a4865657e3bb.png)


##  [FIX] resource_booking: "Involves me" filter 

The filter wasn't working fine due to the `auto_join=True` set in `meeting_id`. It was never displaying pending bookings.

Besides, it wasn't necessary to keep it as a field because it was displayed nowhere and the search could be done directly in the view. This way, there's less python code to maintain and we disable the possibility of having a negative domain, which enters doomed scenarios when x2many fields are involved (see odoo/odoo#43957).

##  [IMP] resource_booking: compatible with hr_holidays_public 

Adding `.with_context(exclude_public_holidays=True)` in needed places to let `hr_holidays_public` do its magic and never allow allocating a booking during a public holidays when that module is properly installed and configured.

![image](https://user-images.githubusercontent.com/973709/126974278-067d6738-03d9-4e6e-8ab4-7e7653332b6a.png)

## [IMP] resource_booking: optional name propagated to meeting

- Allow users to optionally define a name for the resource booking.
- Display that name in portal if set.
- Sync it with meeting name when creating it.


https://user-images.githubusercontent.com/973709/127126593-701f0fe7-1afb-41aa-a7c8-2f869a89e563.mp4



@Tecnativa TT30987