### PR TITLE
[FIX] resource_booking: error when recurrent meetings exist

### DIFF
--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -195,6 +195,7 @@
                 <filter
                     name="is_mine"
                     string="Involving me"
+                    context="{'virtual_id': False}"
                     domain="['|', '|', ('partner_id.user_ids', '=', uid), ('meeting_id.attendee_ids.partner_id.user_ids', '=', uid), ('combination_id.resource_ids.user_id', '=', uid)]"
                 />
                 <filter


### PR DESCRIPTION
Without this patch, when entering the Resource Bookings menu, if the current user attended any recurrent meeting, it failed with this error:

```
Server application error
 Error code: 200
 Error message: Odoo Server Error
 Error data message:
 invalid input syntax for integer: "82-20210726143000"
LINE 1: ... AND  ("resource_booking"."meeting_id" in (3,5,81,'82-202107...
                                                             ^

 Error data debug:
 Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 624, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 310, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/opt/odoo/custom/src/odoo/odoo/tools/pycompat.py", line 14, in reraise
    raise value
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 669, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 350, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 915, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 515, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1339, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1331, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 383, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 356, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4936, in search_read
    records = self.search(domain or [], offset=offset, limit=limit, order=order)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1648, in search
    res = self._search(args, offset=offset, limit=limit, order=order, count=count)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4499, in _search
    self._cr.execute(query_str, where_clause_params)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 173, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 250, in execute
    res = self._obj.execute(query, params)
psycopg2.DataError: invalid input syntax for integer: "82-20210726143000"
LINE 1: ... AND  ("resource_booking"."meeting_id" in (3,5,81,'82-202107...
                                                             ^
```

@Tecnativa TT30987