### PR TITLE
[FIX] resource_booking: access error on normal calendar

### DIFF
--- a/resource_booking/views/calendar_event_views.xml
+++ b/resource_booking/views/calendar_event_views.xml
@@ -6,6 +6,7 @@
         <field name="name">calendar.event.view.form.inherit</field>
         <field name="model">calendar.event</field>
         <field name="inherit_id" ref="calendar.view_calendar_event_form" />
+        <field name="groups_id" eval="[(4, ref('group_user'), 0)]" />
         <field name="arch" type="xml">
             <form position="inside">
                 <field name="resource_booking_ids" invisible="1" />


### PR DESCRIPTION
When a user had no resource_booking permissions and opened a calendar event linked to a resource booking, he got an unnecessary access error.

@Tecnativa TT31238