### PR TITLE
[IMP] resource_booking: autoconfirm preselected combination resource attendees

### DIFF
--- a/resource_booking/controllers/portal.py
+++ b/resource_booking/controllers/portal.py
@@ -125,7 +125,9 @@ class CustomerPortal(portal.CustomerPortal):
     )
     def portal_booking_confirm(self, booking_id, access_token, when, **kwargs):
         """Confirm a booking in a given datetime."""
-        booking_sudo = self._get_booking_sudo(booking_id, access_token)
+        booking_sudo = self._get_booking_sudo(booking_id, access_token).with_context(
+            autoconfirm_booking_requester=True
+        )
         when_tz_aware = isoparse(when)
         when_naive = datetime.utcfromtimestamp(when_tz_aware.timestamp())
         try:


### PR DESCRIPTION
When a booking has a preselected resource combination, the resource attendees don't need to reconfirm their attendance to the meeting, because they've already stated that they'll be available on those dates.

@Tecnativa TT31239