### PR TITLE
[FIX] resource_booking: allow combination with other kind of leaves

### DIFF
--- a/resource_booking/models/resource_calendar.py
+++ b/resource_booking/models/resource_calendar.py
@@ -89,7 +89,7 @@ class ResourceCalendar(models.Model):
                         fields.Datetime.context_timestamp(
                             event, fields.Datetime.to_datetime(event.stop)
                         ),
-                        resource,
+                        self.env["resource.calendar.leaves"],
                     )
                 )
         return Intervals(intervals)


### PR DESCRIPTION
When `_leave_intervals_batch()` in `resource.calendar` is extended by other modules that add more leaves for any reason, the returned recordset must be of the `resource.calendar.leaves` model. Otherwise, Odoo fails with:

    TypeError: '<' not supported between instances of 'resource.resource' and 'resource.calendar.leaves'

The resource didn't have a meaning here, so changing it to avoid bug.

@Tecnativa TT31249