### PR TITLE
[FIX] resource_booking: display location and duration on portal

### DIFF
--- a/resource_booking/templates/portal.xml
+++ b/resource_booking/templates/portal.xml
@@ -362,11 +362,18 @@
                         <div class="col-md">
                             <div class="mb-1">
                                 <strong>Location:</strong>
-                                <span t-field="booking_sudo.meeting_id.location" />
+                                <span t-field="booking_sudo.location" />
                             </div>
                             <div class="mb-1">
                                 <strong>Dates:</strong>
                                 <span t-field="booking_sudo.meeting_id.display_time" />
+                            </div>
+                            <div class="mb-1">
+                                <strong>Duration:</strong>
+                                <span
+                                    t-field="booking_sudo.duration"
+                                    t-options='{"widget": "float_time"}'
+                                />
                             </div>
                             <div t-if="booking_sudo.requester_advice" class="mb-1">
                                 <strong>Advice:</strong>


### PR DESCRIPTION
Missing part from https://github.com/OCA/calendar/pull/34:

- Display booking duration and location on portal, even on pending state.
- Improve portal test to contemplate new behaviors.

@Tecnativa TT31250