### PR TITLE
[IMP] resource_booking: add organizer

### DIFF
--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -503,6 +503,22 @@ class BackendCase(SavepointCase):
         self.assertFalse(rb.meeting_id)
         self.assertEqual(rb.location, "Office 3")
 
+    def test_organizer_sync(self):
+        """Resource booking and meeting organizers are properly synced."""
+        rb = self.env["resource.booking"].create(
+            {
+                "partner_id": self.partner.id,
+                "type_id": self.rbt.id,
+                "start": "2021-03-01 08:00:00",
+                "duration": 1.5,
+            }
+        )
+        self.assertEqual(rb.user_id, self.env.user)
+        self.assertEqual(rb.meeting_id.user_id, self.env.user)
+        rb.meeting_id.user_id = self.users[1]
+        self.assertEqual(rb.user_id, self.users[1])
+        self.assertEqual(rb.meeting_id.user_id, self.users[1])
+
     def test_resource_booking_display_name(self):
         # Pending booking with no name
         rb = self.env["resource.booking"].create(

--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -152,6 +152,7 @@
                                 groups="base.group_no_one"
                                 readonly="1"
                             />
+                            <field name="user_id" />
                             <field name="is_overdue" invisible="1" />
                             <field name="is_modifiable" invisible="1" />
                             <div


### PR DESCRIPTION
This allows better filtering while in the normal calendar view.

By default, the organizer will be whoever created the booking. Calendar invitations will go out in his name.

Also, avoid sending calendar event modification notifications if the modification isn't the schedule.

@Tecnativa TT31240