### PR TITLE
[FIX] resource_booking: suggest involved partners as followers

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -532,12 +532,20 @@ class ResourceBooking(models.Model):
             new.append((id_, name))
         return new
 
-    def message_get_suggested_recipients(self):
-        recipients = super().message_get_suggested_recipients()
-        for one in self:
-            if one.partner_id:
-                one._message_add_suggested_recipient(
-                    recipients, partner=one.partner_id, reason=_("Requesting partner")
+    def _message_get_suggested_recipients(self):
+        """Suggest related partners."""
+        recipients = super()._message_get_suggested_recipients()
+        for record in self:
+            record._message_add_suggested_recipient(
+                recipients,
+                partner=record.partner_id,
+                reason=self._fields["partner_id"].string,
+            )
+            for partner in record.combination_id.resource_ids.user_id.partner_id:
+                record._message_add_suggested_recipient(
+                    recipients,
+                    partner=partner,
+                    reason=self._fields["combination_id"].string,
                 )
         return recipients
 


### PR DESCRIPTION
Includes those coming from requester and from resource combination.

Fixes this:

![pantallazo_2021-09-15_13-15](https://user-images.githubusercontent.com/973709/133424290-d1d3219e-503c-4e43-a8f9-ebe3854ec562.png)

@Tecnativa TT31901