### PR TITLE
[FIX] resource_booking: correct assignment message

### DIFF
--- a/resource_booking/__manifest__.py
+++ b/resource_booking/__manifest__.py
@@ -27,6 +27,7 @@
         "web_calendar_slot_duration",
     ],
     "data": [
+        "data/mail.xml",
         "security/resource_booking_security.xml",
         "security/ir.model.access.csv",
         "templates/assets.xml",

--- a/resource_booking/data/mail.xml
+++ b/resource_booking/data/mail.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Tecnativa - Jairo Llopis
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<data>
+
+    <!-- Inspired in message_user_assigned -->
+    <template id="message_combination_assigned">
+        <p style="margin: 0px;">
+            Dear user,
+            <br />
+            You have been assigned to the
+            <t t-esc="model_description or 'document'" />
+            <t t-esc="object.name_get()[0][1]" />
+            because you belong to the chosen resource combination:
+            <t t-esc="object.combination_id.name_get()[0][1]" />.
+        </p>
+        <p style="margin-top: 24px; margin-bottom: 16px;">
+            <a t-att-href="'/mail/view?model=%s&amp;res_id=%s' % (object._name, object.id)" style="background-color:#875A7B; padding: 10px; text-decoration: none; color: #fff; border-radius: 5px;">
+                View
+                <t t-esc="model_description or 'document'" />
+            </a>
+        </p>
+    </template>
+
+</data>

--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -462,7 +462,7 @@ class ResourceBooking(models.Model):
                 (
                     partner.id,
                     default_subtype_ids,
-                    "mail.message_user_assigned"
+                    "resource_booking.message_combination_assigned"
                     if partner != self.env.user.partner_id
                     else False,
                 )

--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -1,5 +1,7 @@
 # Copyright 2021 Tecnativa - Jairo Llopis
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from unittest.mock import patch
+
 from freezegun import freeze_time
 from odoo.tests.common import SavepointCase, Form, new_test_user
 from odoo.exceptions import ValidationError
@@ -384,17 +386,19 @@ class BackendCase(SavepointCase):
         rb_user = new_test_user(
             self.env, login="rbu", groups="base.group_user,resource_booking.group_user"
         )
-        rb = (
-            self.env["resource.booking"]
-            .sudo(rb_user)
-            .create(
-                {
-                    "partner_id": self.partner.id,
-                    "type_id": self.rbt.id,
-                    "combination_id": self.rbcs[0].id,
-                }
+        # Enable auto-subscription messaging
+        with patch.object(self.env.registry, "ready", True):
+            rb = (
+                self.env["resource.booking"]
+                .sudo(rb_user)
+                .create(
+                    {
+                        "partner_id": self.partner.id,
+                        "type_id": self.rbt.id,
+                        "combination_id": self.rbcs[0].id,
+                    }
+                )
             )
-        )
         # Creator and resource must already be following
         self.assertEqual(
             rb.message_partner_ids, rb_user.partner_id | self.users[0].partner_id


### PR DESCRIPTION
By using the upstream `mail.message_user_assigned` template, we were getting this exception:

```
odoo.addons.base.models.qweb.QWebException: 'resource.booking' object has no attribute 'user_id'
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/qweb.py", line 348, in _compiled_fn
    return compiled(self, append, new, options, log)
  File "<template>", line 1, in template_2601_10519
AttributeError: 'resource.booking' object has no attribute 'user_id'
```

So I provide a specific template for this kind of subscription notification, which doesn't use that `user_id` field. Besides, it explains better why you're getting it.

@Tecnativa TT32190