### PR TITLE
[FIX] resource_booking: multicompany access

### DIFF
--- a/resource_booking/security/resource_booking_security.xml
+++ b/resource_booking/security/resource_booking_security.xml
@@ -30,6 +30,13 @@
             <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', user.company_id.ids)]</field>
         </record>
 
+        <record id="rule_resource_booking_company" model="ir.rule">
+            <field name="name">Resource booking multi company rule</field>
+            <field name="model_id" ref="model_resource_booking" />
+            <field name="global" eval="True" />
+            <field name="domain_force">['|', ('type_id.company_id', '=', False), ('type_id.company_id', 'child_of', user.company_id.ids)]</field>
+        </record>
+
         <record id="rule_resource_booking_portal" model="ir.rule">
             <field name="name">Resource booking portal rule</field>
             <field name="model_id" ref="model_resource_booking" />


### PR DESCRIPTION
Without this patch, users can list but not read resource bookings that belong to a type of an alien company.

@Tecnativa TT31445