### PR TITLE
[FIX] resource_booking: allow creating if type has categories

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -40,13 +40,7 @@ class ResourceBooking(models.Model):
         ondelete="set null",
         help="Meeting confirmed for this booking.",
     )
-    categ_ids = fields.Many2many(
-        string="Tags",
-        comodel_name="calendar.event.type",
-        compute="_compute_categ_ids",
-        store=True,
-        readonly=False,
-    )
+    categ_ids = fields.Many2many(string="Tags", comodel_name="calendar.event.type")
     combination_id = fields.Many2one(
         comodel_name="resource.booking.combination",
         string="Resources combination",
@@ -159,8 +153,8 @@ class ResourceBooking(models.Model):
             one.access_url = "/my/bookings/%d" % one.id
         return result
 
-    @api.depends("type_id")
-    def _compute_categ_ids(self):
+    @api.onchange("type_id")
+    def _onchange_type_set_categ_ids(self):
         """Copy default tags from RBT when changing it."""
         for one in self:
             if one.type_id:

--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -619,3 +619,13 @@ class BackendCase(SavepointCase):
             rb._message_get_suggested_recipients(),
             {rb.id: [(rb.partner_id.id, "some customer", "Requester")]},
         )
+
+    def test_creating_rbt_has_tags(self):
+        """Creating booking works if type has tags."""
+        categ = self.env["calendar.event.type"].create({"name": "test tag"})
+        self.rbt.categ_ids = categ
+        rb_f = Form(self.env["resource.booking"])
+        rb_f.partner_id = self.partner
+        rb_f.type_id = self.rbt
+        rb = rb_f.save()
+        self.assertEqual(rb.categ_ids, categ)


### PR DESCRIPTION
Without this patch, if you create a resource booking for a type that has categories (tags), it will fail with `CacheMiss` error.

@Tecnativa TT32552