### PR TITLE
[FIX] resource_booking: free meetings by default

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -238,6 +238,12 @@ class ResourceBooking(models.Model):
                     resource_booking_ids=[(6, 0, one.ids)],
                     start=one.start,
                     stop=one.stop,
+                    # If you're not booked, you're free
+                    show_as=(
+                        "busy"
+                        if self.env.user.partner_id in resource_partners
+                        else "free"
+                    ),
                     # These 2 avoid creating event as activity
                     res_model_id=False,
                     res_id=False,

--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -12,7 +12,7 @@ from .common import create_test_data
 _2dt = fields.Datetime.to_datetime
 
 
-@freeze_time("2021-02-26 09:00:00", tick=True)
+@freeze_time("2021-02-26 09:00:00", tick=True)  # Last Friday of February
 class BackendCase(SavepointCase):
     @classmethod
     def setUpClass(cls):
@@ -446,3 +446,48 @@ class BackendCase(SavepointCase):
                 ]
             },
         )
+
+    def test_event_show_as_free(self):
+        """Don't mind about event owner.
+
+        Here I'll create 2 overlapping events. Since I create both, I'll be the
+        owner of both automatically. However, there are 2 RBC available (one is
+        me), so I still should be able to create 2 events.
+        """
+        env = self.env(user=self.users[0])
+        env.user.groups_id = self.env.ref("base.group_user") | self.env.ref(
+            "resource_booking.group_user"
+        )
+        # I'm the last option
+        self.rbt.combination_assignment = "sorted"
+        self.rbt.combination_rel_ids[0].sequence = 10
+        # Create one long event on Monday, where there are 2 RBC available (one is me)
+        rb_f = Form(env["resource.booking"])
+        rb_f.type_id = self.rbt
+        rb_f.start = "2021-03-01 09:00:00"
+        rb_f.stop = "2021-03-01 10:00:00"
+        rb_f.partner_id = self.partner
+        rb1 = rb_f.save()
+        # I'm not booked, so I'm free
+        self.assertEqual(rb1.combination_id, self.rbcs[2])
+        self.assertEqual(rb1.meeting_id.show_as, "free")
+        # Create another event within the previous one
+        rb_f = Form(env["resource.booking"])
+        rb_f.type_id = self.rbt
+        rb_f.start = "2021-03-01 09:00:00"
+        rb_f.stop = "2021-03-01 10:30:00"
+        rb_f.partner_id = self.partner.copy()
+        # Saving works because I'm free
+        rb2 = rb_f.save()
+        # I'm booked this time, so I'm busy
+        self.assertEqual(rb2.combination_id, self.rbcs[0])
+        self.assertEqual(rb2.meeting_id.show_as, "busy")
+        # But if I'm not free for 1st RB, it will fail without available resources
+        rb1.meeting_id.show_as = "busy"
+        rb_f = Form(env["resource.booking"])
+        rb_f.type_id = self.rbt
+        rb_f.start = "2021-03-01 09:30:00"
+        rb_f.stop = "2021-03-01 10:00:00"
+        rb_f.partner_id = self.partner.copy()
+        with self.assertRaises(AssertionError):
+            rb_f.save()


### PR DESCRIPTION
If I'm creating bookings for my colleagues, I'll be the owner of all of the meetings. But that doesn't mean I'll be attending. And OTOH, if I'm part of the bookied resource combination, I'll already be busy due to my attendance status.

So it makes sense to be free by default. However, if I still choose to be busy at that time, I'll create an unavailability as expected.

@Tecnativa TT32666