### PR TITLE
[FIX] resource_booking: free meetings by default

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -300,6 +300,12 @@ class ResourceBooking(models.Model):
                     start=one.start,
                     stop=one.stop,
                     user_id=one.user_id.id,
+                    # If you're not booked, you're free
+                    show_as=(
+                        "busy"
+                        if self.env.user.partner_id in resource_partners
+                        else "free"
+                    ),
                     # These 2 avoid creating event as activity
                     res_model_id=False,
                     res_id=False,


### PR DESCRIPTION
If I'm creating bookings for my colleagues, I'll be the owner of all of the meetings. But that doesn't mean I'll be busy.

With this patch, only when I'm a booked resource will the event be set as busy.

@Tecnativa TT32666 Fw port of https://github.com/OCA/calendar/pull/55