### PR TITLE
[12.0][FIX] resource_booking : previous/next

### DIFF
--- a/resource_booking/templates/portal.xml
+++ b/resource_booking/templates/portal.xml
@@ -20,11 +20,13 @@
         <t t-set="confirm_url" t-value="booking.get_portal_url(suffix='/confirm')" />
         <t t-set="date_format" t-value="res_lang.date_format" />
         <t t-set="time_format" t-value="res_lang.time_format.replace(':%S', '')" />
+        <t t-set="start_next" t-value="start + relativedelta(months=1)" />
+        <t t-set="start_previous" t-value="start - relativedelta(months=1)" />
         <div class="o_booking_calendar">
 
             <div class="alert alert-danger" t-if="not slots">
                 No free slots found this month.
-                <a t-att-href="booking.get_portal_url(suffix='/schedule/%d/%d' % (start.year, start.month + 1))" class="alert-link">
+                <a t-att-href="booking.get_portal_url(suffix='/schedule/%d/%d' % (start_next.year, start_next.month))" class="alert-link">
                     Try next month
                     <i class="fa fa-chevron-right"/>
                 </a>
@@ -42,13 +44,13 @@
                 <thead class="thead-dark">
                     <tr>
                         <th class="text-left">
-                            <a t-if="start > now" t-att-href="booking.get_portal_url(suffix='/schedule/%d/%d' % (start.year, start.month - 1))" class="btn btn-secondary" title="Previous month">
+                            <a t-if="start > now" t-att-href="booking.get_portal_url(suffix='/schedule/%d/%d' % (start_previous.year, start_previous.month))" class="btn btn-secondary" title="Previous month">
                                 <i class="fa fa-chevron-left"></i>
                             </a>
                         </th>
                         <th class="align-middle" colspan="5" t-esc="start.strftime('%B %Y')"></th>
                         <th class="text-right">
-                            <a t-att-href="booking.get_portal_url(suffix='/schedule/%d/%d' % (start.year, start.month + 1))" class="btn btn-secondary" title="Next month">
+                            <a t-att-href="booking.get_portal_url(suffix='/schedule/%d/%d' % (start_next.year, start_next.month))" class="btn btn-secondary" title="Next month">
                                 <i class="fa fa-chevron-right"></i>
                             </a>
                         </th>


### PR DESCRIPTION
Hi,
I found a bug while testing this great module. The Next and Previous buttons in the scheduling_calendar do not behave correctly when switching year.