### PR TITLE
[IMP] resource_booking: faster tests

### DIFF
--- a/resource_booking/tests/common.py
+++ b/resource_booking/tests/common.py
@@ -4,7 +4,11 @@
 
 def create_test_data(obj):
     """Create test data for a case."""
-    obj.env = obj.env(context={"tz": "UTC"})
+    obj.env = obj.env(
+        context=dict(
+            obj.env.context, tracking_disable=True, no_reset_password=True, tz="UTC"
+        )
+    )
     # Create one resource.calendar available on Mondays, another one on
     # Tuesdays, and another one on Mondays and Tuesdays; in that order
     attendances = [

--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -591,6 +591,7 @@ class BackendCase(SavepointCase):
         self.assertEqual(resource_attendees.state, "accepted")
 
     def test_suggested_and_subscribed_recipients(self):
+        self.env = self.env(context=dict(self.env.context, tracking_disable=False))
         # Create a booking as a new user
         rb_user = new_test_user(
             self.env, login="rbu", groups="base.group_user,resource_booking.group_user"
@@ -637,7 +638,9 @@ class BackendCase(SavepointCase):
         owner of both automatically. However, there are 2 RBC available (one is
         me), so I still should be able to create 2 events.
         """
-        env = self.env(user=self.users[0])
+        env = self.env(
+            user=self.users[0], context=dict(self.env.context, tracking_disable=False)
+        )
         env.user.groups_id = self.env.ref("base.group_user") | self.env.ref(
             "resource_booking.group_user"
         )


### PR DESCRIPTION
Apply lessons from https://youtu.be/lT___hG110Q?t=23285 and disable unnecessary mail stuff.

Before:

    odoo.addons.resource_booking.tests.test_backend tested in 16.18s, 9124 queries
    odoo.addons.resource_booking.tests.test_portal tested in 16.42s, 6685 queries

After:

    odoo.addons.resource_booking.tests.test_backend tested in 13.68s, 7873 queries
    odoo.addons.resource_booking.tests.test_portal tested in 15.17s, 5972 queries

@Tecnativa TT31324