### PR TITLE
[FIX] Avoid sending notifications when public user

### DIFF
--- a/resource_booking/models/calendar_event.py
+++ b/resource_booking/models/calendar_event.py
@@ -80,6 +80,9 @@ class CalendarEvent(models.Model):
                 continue
             if attendee.partner_id in rb.combination_id.resource_ids.user_id.partner_id:
                 attendee.state = "accepted"
+        # Don't send notifications if you're a public user
+        if self.env.user._is_public():
+            return result
         # Send invitations like upstream would have done
         to_notify = new_attendees.filtered(lambda a: a.email != self.env.user.email)
         if to_notify and not self.env.context.get("detaching"):


### PR DESCRIPTION
Public users usually don't have an email, so they hit [this error][1].

No test added because anyways the tests in `website_sale_resource_booking` already fail without this patch, and it's hard to find a use case without it.

@Tecnativa TT31328

[1]: https://github.com/odoo/odoo/blob/e7dd314e53a4260dd1494cbcb7dcef1c407e2a8a/addons/mail/models/mail_message.py#L36