### PR TITLE
[13.0][FIX] resource_booking: calendar view performance

### DIFF
--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -10,6 +10,7 @@
             <calendar
                 string="Bookings"
                 date_start="start"
+                date_stop="stop"
                 date_delay="duration"
                 quick_add="false"
                 color="combination_id"


### PR DESCRIPTION
We need a stop parameter. Otherwise, the calendar view could be trying
to render tons of records making the client's browser have a hard time.

cc @Tecnativa TT35062

please check @pedrobaeza @sergio-teruel 