### PR TITLE
[13.0][FIX] resource_booking: performance with recurrent events

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -505,7 +505,10 @@ class ResourceBooking(models.Model):
 
     def write(self, vals):
         """Sync booking with meeting if needed."""
-        result = super().write(vals)
+        # On a database with lots of recurrent calendar events we could get serious
+        # performance downgrades. As we'll be computing them with _sync_meeting later
+        # we'll be avoiding triggering on the super call (i.e. compute methods)
+        result = super(ResourceBooking, self.with_context(virtual_id=False)).write(vals)
         self._sync_meeting()
         return result
 

--- a/resource_booking/models/resource_calendar.py
+++ b/resource_booking/models/resource_calendar.py
@@ -46,9 +46,16 @@ class ResourceCalendar(models.Model):
             and resource.user_id.active
             and resource.user_id
         )
+        # We want to avoid unnecessary queries, which can be quite unperformant when
+        # there are lots of recurrent events.
+        if not resource and not resource_user:
+            return Intervals(intervals)
         # Simple domain to get all possibly conflicting events in a single
         # query; this reduces DB calls and helps the underlying recurring
         # system (in calendar.event) to work smoothly
+        # TODO: There's room for performance improvement when no recurrent events
+        # are to be considered. In that case we could simply use the context key
+        # virtual_id=False. How how can we know it in advance?
         all_events = (
             self.env["calendar.event"]
             .with_context(active_test=True)


### PR DESCRIPTION
`rrule` isn't very performant on iterations. This is used on calendar
events to compute the virtual events set.

We want to avoid calling it too much.

Real case with website_sale_resource_booking (thousands of virtual events):

before: /shop/booking/<id>/schedule: ~25 seconds
after: /shop/booking/<id>/schedule: ~6 seconds

before: /shop/booking/<id>/confirm: ~20 seconds
after: /shop/booking/<id>/confirm: ~3 seconds

before: /shop/checkout: ~18 seconds
after: /shop/checkout: ~2 seconds

before: /shop/address: ~18 seconds
after: /shop/address: ~2 seconds

There's room for improvement anyway

An speed scope for /shop/address before and after:

before:
![image](https://user-images.githubusercontent.com/5040182/172610148-323689c1-b406-4e53-b71f-9a3cdb29f4cc.png)

after:
![image](https://user-images.githubusercontent.com/5040182/172610194-1091f8bd-ad6f-43f0-af01-56815debd3ac.png)




cc @Tecnativa TT37089

ping @pedrobaeza @sergio-teruel @carlosdauden 