### PR TITLE
[FIX] resource_booking: further performance

### DIFF
--- a/resource_booking/models/resource_calendar.py
+++ b/resource_booking/models/resource_calendar.py
@@ -53,13 +53,14 @@ class ResourceCalendar(models.Model):
         # Simple domain to get all possibly conflicting events in a single
         # query; this reduces DB calls and helps the underlying recurring
         # system (in calendar.event) to work smoothly
-        # TODO: There's room for performance improvement when no recurrent events
-        # are to be considered. In that case we could simply use the context key
-        # virtual_id=False. How how can we know it in advance?
+        domain = [("start", "<=", end_dt), ("stop", ">=", start_dt)]
+        # Anyway up to this version, is more performant to restrict as much as possible
+        # the events to avoid recurrent events.
+        # TODO: in v14 we should test which approach remains the most performant
+        if resource_user:
+            domain += [("partner_ids", "=", resource_user.partner_id.id)]
         all_events = (
-            self.env["calendar.event"]
-            .with_context(active_test=True)
-            .search([("start", "<=", end_dt), ("stop", ">=", start_dt)])
+            self.env["calendar.event"].with_context(active_test=True).search(domain)
         )
         for event in all_events:
             real_event = self.env["calendar.event"].browse(


### PR DESCRIPTION
Restrict the events which our resource is participating in to avoid loading recurrent events as much as possible. This is really more performant in v13. A simple showcase:

```python
>>> timeit(
        lambda: env["calendar.event"].with_context(active_test=True).search(
            [("partner_ids", "=", partner.id)]
        ), number=1
    )
0.06541907804785296
>>> timeit(
        lambda: env["calendar.event"].with_context(active_test=True).search([])
        , number=1
    )
1.194712486001663
```

In the context of website booking:

Before

```log
"GET /shop/checkout?express=1 HTTP/1.1" 302 - 38 0.034 0.060
"GET /shop/booking/1/schedule HTTP/1.1" 200 - 982 0.533 5.549
"POST /shop/booking/1/confirm?access_token=xxx-xxx-xxx HTTP/1.1" 302 - 555 1.374 3.169
"GET /shop/booking/2/schedule HTTP/1.1" 302 - 19 0.009 0.014
"GET /shop/checkout HTTP/1.1" 302 - 152 0.111 2.391
"GET /shop/address HTTP/1.1" 200 - 188 0.155 1.969
```

After

```logs
"GET /shop/checkout?express=1 HTTP/1.1" 302 - 38 0.033 0.056
"GET /shop/booking/1/schedule HTTP/1.1" 200 - 945 0.479 4.812
"POST /shop/booking/1/confirm?access_token=xxx-xxx-xxx HTTP/1.1" 302 - 521 1.412 0.461
"GET /shop/booking/2/schedule HTTP/1.1" 302 - 19 0.008 0.017
"GET /shop/checkout HTTP/1.1" 302 - 135 0.091 0.161
"GET /shop/address HTTP/1.1" 200 - 189 0.133 0.289
```

cc @Tecnativa TT37089