### PR TITLE
[FIX] calendar_partner_color display colors on filters

### DIFF
--- a/calendar_partner_color/__manifest__.py
+++ b/calendar_partner_color/__manifest__.py
@@ -9,7 +9,7 @@
     "website": "https://github.com/OCA/calendar",
     "author": "Akretion, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "depends": ["calendar"],
+    "depends": ["calendar", "web_calendar_color_field"],
     "data": [
         "views/calendar_event.xml",
         "views/partner.xml",

--- a/calendar_partner_color/views/calendar_event.xml
+++ b/calendar_partner_color/views/calendar_event.xml
@@ -8,6 +8,9 @@
             <xpath expr="//calendar" position="attributes">
                 <attribute name="color">color</attribute>
             </xpath>
+            <field name="user_id" position="attributes">
+                <attribute name="color">color</attribute>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
When using this module, the colors are properly displayed on calendar, although there is no legend anymore, meaning that on the right section where you can filter on what to display, you do not get any color on owner, so it is very difficult to assess which color belongs to whom...

I added dependency on web_calendar_color_field (from OCA web repo) in order to display the color on filters as well.