### PR TITLE
[14.0][IMP] resource_booking: Allow a booking to span more than one calendar day

### DIFF
--- a/resource_booking/readme/newsfragments/77.feature.rst
+++ b/resource_booking/readme/newsfragments/77.feature.rst
@@ -1,0 +1,1 @@
+Bookings can now span more than one calendar day.

--- a/resource_booking/tests/common.py
+++ b/resource_booking/tests/common.py
@@ -10,7 +10,8 @@ def create_test_data(obj):
         )
     )
     # Create one resource.calendar available on Mondays, another one on
-    # Tuesdays, and another one on Mondays and Tuesdays; in that order
+    # Tuesdays, and another one on Mondays and Tuesdays; in that order.
+    # Also create an all-day calendar for Saturday and Sunday.
     attendances = [
         (
             0,
@@ -34,12 +35,46 @@ def create_test_data(obj):
                 "day_period": "morning",
             },
         ),
+        (
+            0,
+            0,
+            {
+                "name": "Fridays",
+                "dayofweek": "4",
+                "hour_from": 0,
+                "hour_to": 23.99,
+                "day_period": "morning",
+            },
+        ),
+        (
+            0,
+            0,
+            {
+                "name": "Saturdays",
+                "dayofweek": "5",
+                "hour_from": 0,
+                "hour_to": 23.99,
+                "day_period": "morning",
+            },
+        ),
+        (
+            0,
+            0,
+            {
+                "name": "Sunday",
+                "dayofweek": "6",
+                "hour_from": 0,
+                "hour_to": 23.99,
+                "day_period": "morning",
+            },
+        ),
     ]
     obj.r_calendars = obj.env["resource.calendar"].create(
         [
-            {"name": "Mon", "attendance_ids": attendances[:1], "tz": "UTC"},
-            {"name": "Tue", "attendance_ids": attendances[1:], "tz": "UTC"},
-            {"name": "MonTue", "attendance_ids": attendances, "tz": "UTC"},
+            {"name": "Mon", "attendance_ids": [attendances[0]], "tz": "UTC"},
+            {"name": "Tue", "attendance_ids": [attendances[1]], "tz": "UTC"},
+            {"name": "MonTue", "attendance_ids": attendances[0:2], "tz": "UTC"},
+            {"name": "FriSun", "attendance_ids": attendances[2:], "tz": "UTC"},
         ]
     )
     # Create one material resource for each of those calendars; same order
@@ -62,7 +97,7 @@ def create_test_data(obj):
                 "login": "user_%d" % num,
                 "name": "User %d" % num,
             }
-            for num in range(3)
+            for num, _ in enumerate(obj.r_calendars)
         ]
     )
     obj.r_users = obj.env["resource.resource"].create(
@@ -85,7 +120,7 @@ def create_test_data(obj):
             for (user, material) in zip(obj.r_users, obj.r_materials)
         ]
     )
-    # Create one RBT that includes all 3 RBCs as available combinations
+    # Create one RBT that includes all RBCs as available combinations
     obj.rbt = obj.env["resource.booking.type"].create(
         {
             "name": "Test resource booking type",

--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -11,6 +11,11 @@ from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests.common import Form, SavepointCase, new_test_user, users
 
+from odoo.addons.resource.models.resource import Intervals
+from odoo.addons.resource_booking.models.resource_booking import (
+    _availability_is_fitting,
+)
+
 from .common import create_test_data
 
 _2dt = fields.Datetime.to_datetime
@@ -107,6 +112,116 @@ class BackendCase(SavepointCase):
                 "combination_id": rbc_mon.id,
                 "combination_auto_assign": False,
             }
+        )
+
+    def test_scheduling_constraints_span_two_days(self):
+        # Booking can span across two calendar days.
+        cal_frisun = self.r_calendars[3]
+        rbc_frisun = self.rbcs[3]
+        self.rbt.resource_calendar_id = cal_frisun
+        self.env["resource.booking"].create(
+            {
+                "partner_id": self.partner.id,
+                "start": "2021-03-06 23:00:00",
+                "duration": 2,
+                "type_id": self.rbt.id,
+                "combination_id": rbc_frisun.id,
+                "combination_auto_assign": False,
+            }
+        )
+        # Booking cannot overlap.
+        with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            self.env["resource.booking"].create(
+                {
+                    "partner_id": self.partner.id,
+                    "start": "2021-03-06 22:00:00",
+                    "duration": 4,
+                    "type_id": self.rbt.id,
+                    "combination_id": rbc_frisun.id,
+                    "combination_auto_assign": False,
+                }
+            )
+        # Test a case where there is an overlap, but the conflict happens at
+        # 00:00 exactly.
+        self.env["resource.booking"].create(
+            {
+                "partner_id": self.partner.id,
+                "start": "2021-03-14 00:00:00",
+                "duration": 1,
+                "type_id": self.rbt.id,
+                "combination_id": rbc_frisun.id,
+                "combination_auto_assign": False,
+            }
+        )
+        with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            self.env["resource.booking"].create(
+                {
+                    "partner_id": self.partner.id,
+                    "start": "2021-03-13 23:00:00",
+                    "duration": 4,
+                    "type_id": self.rbt.id,
+                    "combination_id": rbc_frisun.id,
+                    "combination_auto_assign": False,
+                }
+            )
+        # If there are too many minutes between the end and start of the two
+        # dates, the booking cannot be contiguous.
+        cal_frisun.attendance_ids.write({"hour_to": 23.96})  # 23:58
+        with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            self.env["resource.booking"].create(
+                {
+                    "partner_id": self.partner.id,
+                    "start": "2021-03-20 23:00:00",
+                    "duration": 2,
+                    "type_id": self.rbt.id,
+                    "combination_id": rbc_frisun.id,
+                    "combination_auto_assign": False,
+                }
+            )
+
+    def test_scheduling_constraints_span_three_days(self):
+        # Booking can span across two calendar days.
+        cal_frisun = self.r_calendars[3]
+        rbc_frisun = self.rbcs[3]
+        self.rbt.resource_calendar_id = cal_frisun
+        self.env["resource.booking"].create(
+            {
+                "partner_id": self.partner.id,
+                "start": "2021-03-05 23:00:00",
+                "duration": 24 * 2,
+                "type_id": self.rbt.id,
+                "combination_id": rbc_frisun.id,
+                "combination_auto_assign": False,
+            }
+        )
+
+    def test_availability_is_fitting_malformed_date_skip(self):
+        """Test a case for malformed data where a date is skipped in the
+        available_intervals list of tuples.
+        """
+        recset = self.env["resource.booking"]
+        tuples = [
+            (datetime(2021, 3, 1, 18, 0), datetime(2021, 3, 1, 23, 59), recset),
+            (datetime(2021, 3, 2, 0, 0), datetime(2021, 3, 2, 23, 59), recset),
+            (datetime(2021, 3, 3, 0, 0), datetime(2021, 3, 3, 18, 0), recset),
+        ]
+        available_intervals = Intervals(tuples)
+        self.assertTrue(
+            _availability_is_fitting(
+                available_intervals,
+                datetime(2021, 3, 1, 18, 0),
+                datetime(2021, 3, 3, 18, 0),
+            )
+        )
+        # Skip a day by removing it.
+        tuples.pop(1)
+        available_intervals = Intervals(tuples)
+        self.assertFalse(
+            _availability_is_fitting(
+                available_intervals,
+                datetime(2021, 3, 1, 18, 0),
+                datetime(2021, 3, 3, 18, 0),
+            )
         )
 
     def test_rbc_forced_calendar(self):
@@ -259,7 +374,7 @@ class BackendCase(SavepointCase):
 
     def test_sorted_assignment(self):
         """Set sorted assignment on RBT and test it works correctly."""
-        rbc_mon, rbc_tue, rbc_montue = self.rbcs
+        rbc_mon, rbc_tue, rbc_montue, rbc_frisun = self.rbcs
         with Form(self.rbt) as rbt_form:
             rbt_form.combination_assignment = "sorted"
         # Book next monday at 10:00
@@ -741,5 +856,35 @@ class BackendCase(SavepointCase):
             resource.is_available(
                 utc.localize(datetime(2021, 3, 3, 10, 0)),
                 utc.localize(datetime(2021, 3, 3, 11, 0)),
+            )
+        )
+
+    def test_resource_is_available_span_days(self):
+        # Correctly handle bookings that span across midnight.
+        cal_satsun = self.r_calendars[3]
+        rbc_satsun = self.rbcs[3]
+        resource = rbc_satsun.resource_ids[1]
+        self.rbt.resource_calendar_id = cal_satsun
+        self.env["resource.booking"].create(
+            {
+                "partner_id": self.partner.id,
+                "start": "2021-03-06 23:00:00",
+                "duration": 2,
+                "type_id": self.rbt.id,
+                "combination_id": rbc_satsun.id,
+                "combination_auto_assign": False,
+            }
+        )
+        self.assertFalse(
+            resource.is_available(
+                utc.localize(datetime(2021, 3, 6, 22, 0)),
+                utc.localize(datetime(2021, 3, 7, 2, 0)),
+            )
+        )
+        # Resource is available on the next weekend.
+        self.assertTrue(
+            resource.is_available(
+                utc.localize(datetime(2021, 3, 13, 22, 0)),
+                utc.localize(datetime(2021, 3, 14, 2, 0)),
             )
         )


### PR DESCRIPTION
This PR solves two issues:

- Can't create a booking that lasts from e.g. 23:00 to 1:00.
- Can't create a booking that lasts several days (e.g. rentals).

Internal task: https://gestion.coopiteasy.be/web#id=9834&action=475&active_id=434&model=project.task&view_type=form&menu_id=536