### PR TITLE
[14.0][ADD] new module resource_booking_number_of_attendees

### DIFF
--- a/resource_booking_number_of_attendees/__init__.py
+++ b/resource_booking_number_of_attendees/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import models

--- a/resource_booking_number_of_attendees/__manifest__.py
+++ b/resource_booking_number_of_attendees/__manifest__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+{
+    "name": "Resource Booking Number of Attendees",
+    "summary": "Allow to specify the number of attendees on a booking",
+    "version": "14.0.1.0.0",
+    "category": "Appointments",
+    "website": "https://github.com/OCA/calendar",
+    "author": "Coop IT Easy SC, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": [
+        "resource_booking",
+    ],
+    "data": [
+        "views/resource_booking_view.xml",
+    ],
+}

--- a/resource_booking_number_of_attendees/models/__init__.py
+++ b/resource_booking_number_of_attendees/models/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import resource_booking

--- a/resource_booking_number_of_attendees/models/resource_booking.py
+++ b/resource_booking_number_of_attendees/models/resource_booking.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo import fields, models
+
+
+class ResourceBooking(models.Model):
+    _inherit = "resource.booking"
+
+    # fixme: store this in the meeting instead of in the booking (see roadmap)
+    number_of_attendees = fields.Integer("Number of Attendees", default=1)

--- a/resource_booking_number_of_attendees/readme/CONTRIBUTORS.rst
+++ b/resource_booking_number_of_attendees/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Coop IT Easy SC <https://coopiteasy.be>`_:
+
+  * hugues de keyzer

--- a/resource_booking_number_of_attendees/readme/DESCRIPTION.rst
+++ b/resource_booking_number_of_attendees/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This modules adds a field to bookings to allow to specify the number of
+attendees.

--- a/resource_booking_number_of_attendees/readme/ROADMAP.rst
+++ b/resource_booking_number_of_attendees/readme/ROADMAP.rst
@@ -1,0 +1,9 @@
+The ``number_of_attendees`` field is defined directly on the resource booking.
+While it makes sense to have it there, it would make more sense and be more
+useful to store it in the meeting, in the same way as the location field.
+
+However, calendar events already have a list of attendees, so it could be
+confusing if the two fields are not related.
+
+Adding this field to ``calendar.event`` could be done in a separate module
+that does not depend on ``resource.booking``.

--- a/resource_booking_number_of_attendees/views/resource_booking_view.xml
+++ b/resource_booking_number_of_attendees/views/resource_booking_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<odoo>
+
+    <record id="resource_booking_view_form" model="ir.ui.view">
+        <field name="name">Resource booking form</field>
+        <field name="model">resource.booking</field>
+        <field name="inherit_id" ref="resource_booking.resource_booking_form" />
+        <field name="arch" type="xml">
+            <field name="location" position="after">
+                <field name="number_of_attendees" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/resource_booking_number_of_attendees/odoo/addons/resource_booking_number_of_attendees
+++ b/setup/resource_booking_number_of_attendees/odoo/addons/resource_booking_number_of_attendees
@@ -1,0 +1,1 @@
+../../../../resource_booking_number_of_attendees

--- a/setup/resource_booking_number_of_attendees/setup.py
+++ b/setup/resource_booking_number_of_attendees/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
this module only adds an integer field to resource bookings to store the number of attendees (independently of odoo meeting attendees). it can be useful for the organizer of bookings that involves groups of people to know the amount of (unmanaged) material should be prepared.