### PR TITLE
[14.0][IMP] resource_booking: Change the position of the description field for a correct display.

### DIFF
--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -156,7 +156,6 @@
                                 />
                             </div>
                             <field name="categ_ids" widget="many2many_tags" />
-                            <field name="description" />
                         </group>
                         <group name="meeting" string="Meeting">
                             <field
@@ -184,6 +183,7 @@
                             <field name="stop" />
                             <field name="location" />
                         </group>
+                        <field name="description" colspan="4" />
                     </group>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
Change the position of the description field for a correct display.

**Before**:
![antes](https://user-images.githubusercontent.com/4117568/221519450-f46881f6-67a8-4084-8b85-2695fdedb0ab.png)

**After**:
![despues](https://user-images.githubusercontent.com/4117568/221519482-13eeef32-2a8b-4f3b-862a-473901f54baa.png)

Please @pedrobaeza can you review it?

@Tecnativa