### PR TITLE
[14.0][FIX] resource_booking: Don't fail with multiple internal attendees

### DIFF
--- a/resource_booking/models/calendar_event.py
+++ b/resource_booking/models/calendar_event.py
@@ -91,22 +91,21 @@ class CalendarEvent(models.Model):
         not a real case for now.
         """
         attendee_commands = super()._attendees_values(partner_commands)
-        ctx_partner_id = False
+        partner_ids = False
         for cmd in self.env.context.get("resource_booking_ids", []):
             if cmd[0] == 0 and not cmd[2].get("combination_auto_assign", True):
-                ctx_partner_id = cmd[2]["partner_id"]
+                partner_ids = [cmd[2]["partner_id"]]
             elif cmd[0] == 6:
                 rb = self.env["resource.booking"].browse(cmd[2])
                 if rb.combination_auto_assign:
                     continue  # only auto-confirm if handpicked combination
-                ctx_partner_id = rb.combination_id.resource_ids.user_id.partner_id.id
+                partner_ids = rb.combination_id.resource_ids.user_id.partner_id.ids
         for command in attendee_commands:
             if command[0] != 0:
                 continue
-            att_partner_id = ctx_partner_id
-            if not att_partner_id:
+            if not partner_ids:
                 rb = self.resource_booking_ids
-                att_partner_id = rb.combination_id.resource_ids.user_id.partner_id.id
-            if command[2]["partner_id"] == att_partner_id:
+                partner_ids = rb.combination_id.resource_ids.user_id.partner_id.ids
+            if command[2]["partner_id"] in partner_ids:
                 command[2]["state"] = "accepted"
         return attendee_commands


### PR DESCRIPTION
Steps to reproduce:

- Create a resource combination with 2 user resources.
- Create a type with such resource combination.
- Create a resouce booking forcing manually such resource combination.
- Book from the portal a slot for it.

Result: Singleton error

```
File "/opt/odoo/auto/addons/resource_booking/controllers/portal.py", line 134, in portal_booking_confirm
  booking_form.start = when_naive
File "/opt/odoo/custom/src/odoo/odoo/tests/common.py", line 1979, in __exit__
  self.save()
File "/opt/odoo/custom/src/odoo/odoo/tests/common.py", line 1996, in save
  r.write(values)
File "/opt/odoo/auto/addons/resource_booking/models/resource_booking.py", line 509, in write
  self._sync_meeting()
File "/opt/odoo/auto/addons/resource_booking/models/resource_booking.py", line 337, in _sync_meeting
  _self.env["calendar.event"].create(to_create)
File "<decorator-gen-216>", line 2, in create
File "/opt/odoo/custom/src/odoo/odoo/api.py", line 348, in _model_create_multi
  return create(self, arg)
File "/opt/odoo/auto/addons/crm/models/calendar.py", line 40, in create
  events = super(CalendarEvent, self).create(vals)
File "<decorator-gen-201>", line 2, in create
File "/opt/odoo/custom/src/odoo/odoo/api.py", line 348, in _model_create_multi
  return create(self, arg)
File "/opt/odoo/auto/addons/resource_booking/models/calendar_event.py", line 65, in create
  records += super(
File "<decorator-gen-183>", line 2, in create
File "/opt/odoo/custom/src/odoo/odoo/api.py", line 347, in _model_create_multi
  return create(self, [arg])
File "<decorator-gen-148>", line 2, in create
File "/opt/odoo/custom/src/odoo/odoo/api.py", line 348, in _model_create_multi
  return create(self, arg)
File "/opt/odoo/auto/addons/calendar/models/calendar_event.py", line 763, in create
  vals_list = [
File "/opt/odoo/auto/addons/calendar/models/calendar_event.py", line 764, in <listcomp>
  dict(vals, attendee_ids=self._attendees_values(vals['partner_ids']))
File "/opt/odoo/auto/addons/resource_booking/models/calendar_event.py", line 102, in _attendees_values
  ctx_partner_id = rb.combination_id.resource_ids.user_id.partner_id.id
File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 3822, in __get__
  raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: res.partner(6, 4771)
```

This is because there can be several linked users, but the code is assuming that there's only one.

This commits fixes such possibility.

@Tecnativa 