### PR TITLE
[14.0][FIX] resource_booking: Allow non RB users to handle calendar events

### DIFF
--- a/resource_booking/models/calendar_event.py
+++ b/resource_booking/models/calendar_event.py
@@ -19,12 +19,12 @@ class CalendarEvent(models.Model):
     @api.constrains("resource_booking_ids", "start", "stop")
     def _check_bookings_scheduling(self):
         """Scheduled bookings must have no conflicts."""
-        bookings = self.mapped("resource_booking_ids")
+        bookings = self.sudo().resource_booking_ids
         return bookings._check_scheduling()
 
     def _validate_booking_modifications(self):
         """Make sure you can cancel a booking meeting."""
-        bookings = self.mapped("resource_booking_ids")
+        bookings = self.sudo().resource_booking_ids
         modifiable = bookings.filtered("is_modifiable")
         frozen = bookings - modifiable
         if frozen:
@@ -104,7 +104,7 @@ class CalendarEvent(models.Model):
             if command[0] != 0:
                 continue
             if not partner_ids:
-                rb = self.resource_booking_ids
+                rb = self.sudo().resource_booking_ids
                 partner_ids = rb.combination_id.resource_ids.user_id.partner_id.ids
             if command[2]["partner_id"] in partner_ids:
                 command[2]["state"] = "accepted"

--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -9,7 +9,7 @@ from pytz import utc
 
 from odoo import fields
 from odoo.exceptions import ValidationError
-from odoo.tests.common import Form, SavepointCase, new_test_user
+from odoo.tests.common import Form, SavepointCase, new_test_user, users
 
 from .common import create_test_data
 
@@ -22,6 +22,20 @@ class BackendCase(SavepointCase):
     def setUpClass(cls):
         super().setUpClass()
         create_test_data(cls)
+        cls.plain_user = new_test_user(cls.env, login="plain", groups="base.group_user")
+
+    @users("plain")
+    def test_plain_user_calendar_event(self):
+        """Check that a simple user is able to handle manual calendar events."""
+        event = self.env["calendar.event"].create(
+            {
+                "name": "Test calendar event",
+                "start": "2023-01-01 00:00:00",
+                "stop": "2023-01-01 01:00:00",
+            }
+        )
+        event.write({"partner_ids": [(4, self.partner.id)]})
+        event.unlink()
 
     def test_scheduling_conflict_constraints(self):
         # Combination is available on Mondays and Tuesdays


### PR DESCRIPTION
Steps to reproduce:

- Create a calendar event
- Edit it
- Add an attendee
- Save it

Result: you get a permission error to resource.booking

This is because there are some operations done on resource bookings from the calendar events. The solution is to do such operations with sudo.

@Tecnativa 