### PR TITLE
[14.0][FIX] resource_booking: Force to send calendar event author notification.

### DIFF
--- a/resource_booking/models/calendar_event.py
+++ b/resource_booking/models/calendar_event.py
@@ -57,6 +57,8 @@ class CalendarEvent(models.Model):
         """Transfer resource booking to _attendees_values by context.
 
         We need to serialize the creation in that case.
+        mail_notify_author key from context is necessary to force the notification
+        to be sent to author.
         """
         vals_list2 = []
         records = self.env["calendar.event"]
@@ -65,7 +67,8 @@ class CalendarEvent(models.Model):
                 records += super(
                     CalendarEvent,
                     self.with_context(
-                        resource_booking_ids=vals["resource_booking_ids"]
+                        resource_booking_ids=vals["resource_booking_ids"],
+                        mail_notify_author=True,
                     ),
                 ).create(vals)
             else:


### PR DESCRIPTION
Force to send calendar event author notification (https://github.com/odoo/odoo/blob/14.0/addons/mail/models/mail_thread.py#L2470).

Steps to reproduce:

- Create a booking
- Set a manual assigned
- Share + confirm (with portal)
- User has been notified

Please @pedrobaeza can you review it?

@Tecnativa TT40302