### PR TITLE
[14.0][IMP] color booking calendar events color by type

### DIFF
--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -13,7 +13,7 @@
                 date_stop="stop"
                 date_delay="duration"
                 quick_add="false"
-                color="combination_id"
+                color="type_id"
             >
                 <field name="name" invisible="True" />
                 <field name="partner_id" avatar_field="image_128" />


### PR DESCRIPTION
make the color of resource booking calendar events depend on the booking type instead of on the resource combination.