### PR TITLE
[13.0][FIX] resource_booking: remove test dependency from manifest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 # generated from manifests external_dependencies
 cssselect
-freezegun

--- a/resource_booking/__manifest__.py
+++ b/resource_booking/__manifest__.py
@@ -17,8 +17,6 @@
         "python": [
             # Used implicitly
             "cssselect",
-            # Only for tests
-            "freezegun",
         ],
     },
     "depends": [


### PR DESCRIPTION
I think test dependencies should not be included in the manifest, otherwise it is forcing to install them in production environments where it is not really needed.