### PR TITLE
[15.0][FIX] resource_booking: Add class to schedule page to show full dropdown if opened at the bottom

### DIFF
--- a/resource_booking/static/src/scss/portal.scss
+++ b/resource_booking/static/src/scss/portal.scss
@@ -6,3 +6,7 @@
     max-height: 40vh;
     overflow: auto;
 }
+// Show full dropdown if opened at the bottom
+.resource_booking_portal_schedule {
+    overflow: initial;
+}

--- a/resource_booking/templates/portal.xml
+++ b/resource_booking/templates/portal.xml
@@ -545,6 +545,7 @@
             </t>
             <!-- Scheduling form -->
             <t t-call="portal.portal_record_layout">
+                <t t-set="classes" t-value="'resource_booking_portal_schedule'" />
                 <t t-set="card_header">
                     <t t-call="resource_booking.resource_booking_portal_header" />
                 </t>


### PR DESCRIPTION
Add class to schedule page to show full dropdown if opened at the bottom

**Before**
![antes](https://github.com/OCA/calendar/assets/4117568/09b3942e-2f75-451a-97ec-04cf771bac2f)

**After**
![despues](https://github.com/OCA/calendar/assets/4117568/ecc1a453-0c93-4c32-af02-774592565305)

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT45274