### PR TITLE
[15.0][FIX] resource_booking: Don't fail on archived resource

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -391,7 +391,9 @@ class ResourceBooking(models.Model):
         if not has_meeting:
             return
         # Ensure all scheduled bookings have booked some resources
-        has_rbc = self.filtered("combination_id.resource_ids")
+        has_rbc = self.with_context(active_test=False).filtered(
+            "combination_id.resource_ids"
+        )
         missing_rbc = has_meeting - has_rbc
         if missing_rbc:
             raise ValidationError(


### PR DESCRIPTION
**Steps to reproduce the problem:**

- Create an employee.
- Create a resource booking combination with such employee.
- Create or modify a resource booking type including the previous combination.
- Create a resource booking using that type and combination, and schedule it.
- Archive the employee.
- Do any change on the resource booking type.

**Current behavior:**

Error saying: "Cannot schedule these bookings because no resources are selected for them:..."

**Expected behavior:**

No error.

The problem is that we do the checks without taking into account the archived resource, and thus, it fails. Using active_test=False makes them to appear for the check.

@Tecnativa