### PR TITLE
[15.0][ADD] resource_boooking: Add videocall location in resource booking

### DIFF
--- a/resource_booking/i18n/es.po
+++ b/resource_booking/i18n/es.po
@@ -1,21 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#       * resource_booking
+# 	* resource_booking
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 12.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-30 10:28+0000\n"
-"PO-Revision-Date: 2021-04-30 11:29+0100\n"
-"Last-Translator: Jairo Llopis <jairo.llopis@tecnativa.com>\n"
+"POT-Creation-Date: 2023-10-20 15:55+0000\n"
+"PO-Revision-Date: 2023-10-20 15:55+0000\n"
+"Last-Translator: \n"
 "Language-Team: \n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: resource_booking
 #: code:addons/resource_booking/models/resource_booking.py:0
@@ -141,6 +139,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:resource_booking.resource_booking_portal_form
 msgid "<strong>Location:</strong>"
 msgstr "<strong>Ubicación:</strong>"
+
+#. module: resource_booking
+#: model_terms:ir.ui.view,arch_db:resource_booking.resource_booking_portal_form
+msgid "<strong>Meeting URL:</strong>"
+msgstr ""
 
 #. module: resource_booking
 #: model_terms:ir.ui.view,arch_db:resource_booking.resource_booking_portal_form
@@ -303,7 +306,7 @@ msgstr "Reservas/citas disponibles para este tipo"
 #. module: resource_booking
 #: model:ir.model,name:resource_booking.model_calendar_event
 msgid "Calendar Event"
-msgstr ""
+msgstr "Evento de calendario"
 
 #. module: resource_booking
 #: model_terms:ir.ui.view,arch_db:resource_booking.resource_booking_form
@@ -324,8 +327,7 @@ msgid ""
 "\n"
 "- %s"
 msgstr ""
-"No se pueden agendar estas reservas/citas porque no se les han seleccionado "
-"recursos:\n"
+"No se pueden agendar estas reservas/citas porque no se les han seleccionado recursos:\n"
 "\n"
 "- %s"
 
@@ -333,22 +335,19 @@ msgstr ""
 #: code:addons/resource_booking/models/resource_booking.py:0
 #, python-format
 msgid ""
-"Cannot schedule these bookings because they do not fit in their type or "
-"resources calendars, or because all resources are busy:\n"
+"Cannot schedule these bookings because they do not fit in their type or resources calendars, or because all resources are busy:\n"
 "\n"
 "- %s"
 msgstr ""
-"No se pueden agendar estas reservas/citas porque no encajan en los "
-"calendarios de sus tipos o recursos, o porque todos sus recursos están "
-"ocupados:\n"
+"No se pueden agendar estas reservas/citas porque no encajan en los calendarios de sus tipos o recursos, o porque todos sus recursos están ocupados:\n"
 "\n"
 "- %s"
 
 #. module: resource_booking
 #: model:ir.model.fields,help:resource_booking.field_resource_booking_type__combination_assignment
 msgid ""
-"Choose how to auto-assign resource combinations. It has no effect if assiged "
-"manually."
+"Choose how to auto-assign resource combinations. It has no effect if assiged"
+" manually."
 msgstr ""
 "Escoja cómo autoasignar combinaciones de recursos. No tendrá efecto si se "
 "asigna manualmente."
@@ -584,9 +583,7 @@ msgstr "Si está marcado, hay nuevos mensajes que requieren de su atención."
 
 #. module: resource_booking
 #: model:ir.model.fields,help:resource_booking.field_resource_booking__message_has_error
-#: model:ir.model.fields,help:resource_booking.field_resource_booking__message_has_sms_error
 #: model:ir.model.fields,help:resource_booking.field_resource_booking_type__message_has_error
-#: model:ir.model.fields,help:resource_booking.field_resource_booking_type__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
 msgstr "Si está marcado, algunos mensajes no se pudieron entregar."
 
@@ -694,6 +691,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:resource_booking.resource_booking_form
 msgid "Meeting"
 msgstr "Reunión"
+
+#. module: resource_booking
+#: model:ir.model.fields,field_description:resource_booking.field_resource_booking__videocall_location
+#: model:ir.model.fields,field_description:resource_booking.field_resource_booking_type__videocall_location
+msgid "Meeting URL"
+msgstr ""
 
 #. module: resource_booking
 #: model:ir.model.fields,help:resource_booking.field_resource_booking__meeting_id
@@ -835,8 +838,8 @@ msgstr "Solo puede existir un evento por reserva de recursos."
 #: model_terms:ir.ui.view,arch_db:resource_booking.resource_booking_form
 msgid "Open a calendar to schedule a meeting for this booking request."
 msgstr ""
-"Abrir un calendario para agendar una reunión para esta solicitud de reserva/"
-"cita."
+"Abrir un calendario para agendar una reunión para esta solicitud de "
+"reserva/cita."
 
 #. module: resource_booking
 #: model:ir.model.fields,field_description:resource_booking.field_resource_booking__user_id
@@ -859,8 +862,7 @@ msgid ""
 msgstr ""
 "Pendiente: No se ha agendado ninguna reunión.\n"
 "Agendada: El solicitante todavía no ha confirmado su asistencia.\n"
-"Confirmada: La reunión ha sido agendada, y el solicitante ha confirmado su "
-"asistencia.\n"
+"Confirmada: La reunión ha sido agendada, y el solicitante ha confirmado su asistencia.\n"
 "Cancelada: La reunión se ha borrado y la reserva/cita se ha archivado."
 
 #. module: resource_booking
@@ -923,7 +925,7 @@ msgstr ""
 #. module: resource_booking
 #: model:ir.model,name:resource_booking.model_resource_calendar
 msgid "Resource Working Time"
-msgstr "Horario de trabajo del recurso"
+msgstr "Tiempo de Trabajo de Recursos"
 
 #. module: resource_booking
 #: model:ir.model.fields,field_description:resource_booking.field_calendar_event__resource_booking_ids
@@ -985,12 +987,6 @@ msgstr "Usuario responsable"
 #: model:ir.model.fields,help:resource_booking.field_resource_booking_type__resource_calendar_id
 msgid "Restrict bookings to this schedule."
 msgstr "Restringir reservas/citas a este horario."
-
-#. module: resource_booking
-#: model:ir.model.fields,field_description:resource_booking.field_resource_booking__message_has_sms_error
-#: model:ir.model.fields,field_description:resource_booking.field_resource_booking_type__message_has_sms_error
-msgid "SMS Delivery error"
-msgstr ""
 
 #. module: resource_booking
 #: model_terms:ir.ui.view,arch_db:resource_booking.portal_breadcrumbs
@@ -1100,11 +1096,11 @@ msgstr "Etiquetas"
 #: model:ir.model.fields,help:resource_booking.field_resource_booking__requester_advice
 #: model:ir.model.fields,help:resource_booking.field_resource_booking_type__requester_advice
 msgid ""
-"Text that will appear by default in portal invitation emails and in calendar "
-"views for scheduling."
+"Text that will appear by default in portal invitation emails and in calendar"
+" views for scheduling."
 msgstr ""
-"Texto que aparecerá por defecto en los correos electrónicos de invitación al "
-"portal y en las vistas de calendario para agendar."
+"Texto que aparecerá por defecto en los correos electrónicos de invitación al"
+" portal y en las vistas de calendario para agendar."
 
 #. module: resource_booking
 #: model_terms:ir.ui.view,arch_db:resource_booking.portal_my_bookings
@@ -1115,8 +1111,8 @@ msgstr "Actualmente no hay reservas/citas en su cuenta."
 #: model_terms:ir.actions.act_window,help:resource_booking.resource_booking_type_action
 msgid ""
 "These records categorize resource bookings and apply restrictions to them, "
-"such as available resource combinations, availability schedules and interval "
-"duration."
+"such as available resource combinations, availability schedules and interval"
+" duration."
 msgstr ""
 "Estos registros categorizan las reservas/citas de recursos y les aplican "
 "restricciones, como combinaciones de recursos disponibles, horarios de "
@@ -1238,8 +1234,8 @@ msgstr "Historial de comunicaciones del sitio web"
 #. module: resource_booking
 #: model:ir.model.fields,help:resource_booking.field_resource_booking__combination_auto_assign
 msgid ""
-"When checked, resource combinations will be (un)assigned automatically based "
-"on their availability during the booking dates."
+"When checked, resource combinations will be (un)assigned automatically based"
+" on their availability during the booking dates."
 msgstr ""
 
 #. module: resource_booking
@@ -1249,18 +1245,18 @@ msgid ""
 "requester didn't place the booking yet."
 msgstr ""
 "Cuando esté agendada, los recursos estarán bloqueados. Cuando esté "
-"pendiente, significa que el solicitante todavía no ha agendado su reserva/"
-"cita."
+"pendiente, significa que el solicitante todavía no ha agendado su "
+"reserva/cita."
 
 #. module: resource_booking
 #: model:ir.model.fields,help:resource_booking.field_resource_booking_type__modifications_deadline
 msgid ""
-"When this deadline has been exceeded, if a booking was not yet confirmed, it "
-"will be canceled automatically. Also, only booking managers will be able to "
-"unschedule or reschedule them. The value is expressed in hours."
+"When this deadline has been exceeded, if a booking was not yet confirmed, it"
+" will be canceled automatically. Also, only booking managers will be able to"
+" unschedule or reschedule them. The value is expressed in hours."
 msgstr ""
-"Cuando esta fecha límite se haya sobrepasado, si una reserva/cita todavía no "
-"se había confirmado, será cancelada automáticamente. También, solo los "
+"Cuando esta fecha límite se haya sobrepasado, si una reserva/cita todavía no"
+" se había confirmado, será cancelada automáticamente. También, solo los "
 "responsables de reservas/citas podrán desagendarla o reagendarla. El valor "
 "se expresa en horas."
 
@@ -1291,13 +1287,11 @@ msgstr "Está a punto de confirmar esta reserva/cita:"
 #: code:addons/resource_booking/models/calendar_event.py:0
 #, python-format
 msgid ""
-"You are not allowed to alter these bookings because they exceeded their "
-"modification deadlines:\n"
+"You are not allowed to alter these bookings because they exceeded their modification deadlines:\n"
 "\n"
 "- %s"
 msgstr ""
-"No puede alterar estas reservas/citas porque han sobrepasado su fecha límite "
-"de modificaciones:\n"
+"No puede alterar estas reservas/citas porque han sobrepasado su fecha límite de modificaciones:\n"
 "\n"
 "- %s"
 
@@ -1305,6 +1299,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:resource_booking.message_combination_assigned
 msgid "because you belong to the chosen resource combination:"
 msgstr ""
-
-#~ msgid "Followers (Channels)"
-#~ msgstr "Seguidores (canales)"

--- a/resource_booking/i18n/resource_booking.pot
+++ b/resource_booking/i18n/resource_booking.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-20 15:09+0000\n"
+"PO-Revision-Date: 2023-10-20 15:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -124,6 +126,11 @@ msgstr ""
 #. module: resource_booking
 #: model_terms:ir.ui.view,arch_db:resource_booking.resource_booking_portal_form
 msgid "<strong>Location:</strong>"
+msgstr ""
+
+#. module: resource_booking
+#: model_terms:ir.ui.view,arch_db:resource_booking.resource_booking_portal_form
+msgid "<strong>Meeting URL:</strong>"
 msgstr ""
 
 #. module: resource_booking
@@ -554,9 +561,7 @@ msgstr ""
 
 #. module: resource_booking
 #: model:ir.model.fields,help:resource_booking.field_resource_booking__message_has_error
-#: model:ir.model.fields,help:resource_booking.field_resource_booking__message_has_sms_error
 #: model:ir.model.fields,help:resource_booking.field_resource_booking_type__message_has_error
-#: model:ir.model.fields,help:resource_booking.field_resource_booking_type__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
 msgstr ""
 
@@ -663,6 +668,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:resource_booking.field_resource_booking__meeting_id
 #: model_terms:ir.ui.view,arch_db:resource_booking.resource_booking_form
 msgid "Meeting"
+msgstr ""
+
+#. module: resource_booking
+#: model:ir.model.fields,field_description:resource_booking.field_resource_booking__videocall_location
+#: model:ir.model.fields,field_description:resource_booking.field_resource_booking_type__videocall_location
+msgid "Meeting URL"
 msgstr ""
 
 #. module: resource_booking
@@ -946,12 +957,6 @@ msgstr ""
 #. module: resource_booking
 #: model:ir.model.fields,help:resource_booking.field_resource_booking_type__resource_calendar_id
 msgid "Restrict bookings to this schedule."
-msgstr ""
-
-#. module: resource_booking
-#: model:ir.model.fields,field_description:resource_booking.field_resource_booking__message_has_sms_error
-#: model:ir.model.fields,field_description:resource_booking.field_resource_booking_type__message_has_sms_error
-msgid "SMS Delivery error"
 msgstr ""
 
 #. module: resource_booking

--- a/resource_booking/models/resource_booking_type.py
+++ b/resource_booking/models/resource_booking_type.py
@@ -65,6 +65,7 @@ class ResourceBookingType(models.Model):
         ),
     )
     location = fields.Char()
+    videocall_location = fields.Char(string="Meeting URL")
     modifications_deadline = fields.Float(
         required=True,
         default=24,

--- a/resource_booking/templates/portal.xml
+++ b/resource_booking/templates/portal.xml
@@ -370,6 +370,15 @@
                                 <span t-field="booking_sudo.location" />
                             </div>
                             <div class="mb-1">
+                                <strong>Meeting URL:</strong>
+                                <a
+                                    t-att-href="booking_sudo.videocall_location"
+                                    target="_blank"
+                                >
+                                    <t t-out="booking_sudo.videocall_location or ''" />
+                                </a>
+                            </div>
+                            <div class="mb-1">
                                 <strong>Dates:</strong>
                                 <span t-field="booking_sudo.meeting_id.display_time" />
                             </div>

--- a/resource_booking/tests/common.py
+++ b/resource_booking/tests/common.py
@@ -130,6 +130,7 @@ def create_test_data(obj):
             ],
             "resource_calendar_id": obj.r_calendars[2].id,
             "location": "Main office",
+            "videocall_location": "Videocall Main office",
         }
     )
     # Create some partner

--- a/resource_booking/tests/test_portal.py
+++ b/resource_booking/tests/test_portal.py
@@ -71,6 +71,7 @@ class PortalCase(HttpCase):
                     "partner_id": self.partner.id,
                     "type_id": self.rbt.id,
                     "location": "Office 2",
+                    "videocall_location": "Videocall Office 2",
                 },
             ]
         )
@@ -85,6 +86,11 @@ class PortalCase(HttpCase):
         )
         self.assertTrue(
             portal_page.cssselect(':contains("Location:") + :contains("Main office")')
+        )
+        self.assertTrue(
+            portal_page.cssselect(
+                ':contains("Meeting URL:") + :contains("Videocall Main office")'
+            )
         )
         link = portal_page.cssselect('a:contains("Schedule")')[0]
         portal_url = link.get("href")
@@ -117,6 +123,11 @@ class PortalCase(HttpCase):
         )
         self.assertTrue(
             public_page.cssselect(':contains("Location:") + :contains("Office 2")')
+        )
+        self.assertTrue(
+            public_page.cssselect(
+                ':contains("Meeting URL:") + :contains("Videocall Office 2")'
+            )
         )
         self.assertTrue(public_page.cssselect('.badge:contains("Pending")'))
         link = public_page.cssselect('a:contains("Schedule")')[0]

--- a/resource_booking/views/resource_booking_type_views.xml
+++ b/resource_booking/views/resource_booking_type_views.xml
@@ -45,6 +45,7 @@
                         </group>
                         <group name="event_defaults" string="Meeting defaults">
                             <field name="location" />
+                            <field name="videocall_location" />
                             <field name="alarm_ids" widget="many2many_tags" />
                             <field
                                 name="categ_ids"

--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -183,6 +183,7 @@
                             />
                             <field name="stop" />
                             <field name="location" />
+                            <field name="videocall_location" />
                         </group>
                         <field name="description" colspan="4" />
                     </group>


### PR DESCRIPTION
- Add videocall location in resource booking as this field already exists in calendar.event
- Videocall location available to set in resource booking type. 
- Get videocall location from meeting only when available.
  
@Tecnativa

TT45337

@pedrobaeza 