### PR TITLE
[15.0][IMP] resource_booking: No create/unlink call if nothing to do

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -417,8 +417,10 @@ class ResourceBooking(models.Model):
                     to_create.append(meeting_vals)
             else:
                 to_delete |= one.meeting_id
-        to_delete.unlink()
-        _self.env["calendar.event"].create(to_create)
+        if to_delete:
+            to_delete.unlink()
+        if to_create:
+            _self.env["calendar.event"].create(to_create)
 
     @api.constrains("combination_id", "meeting_id", "type_id")
     def _check_scheduling(self):


### PR DESCRIPTION
Depending on how the create/unlink overrides are programmed, there can be overheads or blocking things when calling unconditionally these methods, even with an empty list, so let's only call them when there is really something to delete or to create.

This has been discovered as `google_calendar` module is calling Google API on calendar event create (although vals_list being empty), and due to an error with Google API right now, I was not able to create a draft resource booking.

@Tecnativa 