### PR TITLE
[16.0][FIX] resource_booking: Add booking_count to portal values only if requested

### DIFF
--- a/resource_booking/controllers/portal.py
+++ b/resource_booking/controllers/portal.py
@@ -26,8 +26,9 @@ class CustomerPortal(portal.CustomerPortal):
     def _prepare_home_portal_values(self, counters):
         """Compute values for multi-booking portal views."""
         values = super()._prepare_home_portal_values(counters)
-        booking_count = request.env["resource.booking"].search_count([])
-        values.update({"booking_count": booking_count})
+        if "booking_count" in counters:
+            booking_count = request.env["resource.booking"].search_count([])
+            values.update({"booking_count": booking_count})
         return values
 
     def _booking_get_page_view_values(self, booking_sudo, access_token, **kwargs):


### PR DESCRIPTION
Add `booking_count` to portal values only if requested

The `_prepare_home_portal_values()` method sometimes requests `booking_count` and only then should we return the value.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa