### PR TITLE
[16.0][IMP] resource_booking: Add priority to portal_my_home view to prevent side effects in some cases

### DIFF
--- a/resource_booking/templates/portal.xml
+++ b/resource_booking/templates/portal.xml
@@ -260,6 +260,7 @@
         id="portal_my_home"
         inherit_id="portal.portal_my_home"
         customize_show="True"
+        priority="30"
     >
         <xpath expr="//div[hasclass('o_portal_docs')]" position="inside">
             <t t-call="portal.portal_docs_entry">


### PR DESCRIPTION
Add priority to portal_my_home view to prevent side effects in some cases.

In some cases the tour tests fail because it does not find the link to `[href*="/my/bookings"]`. It seems to be related to https://github.com/odoo/odoo/commit/73b4e9b1b671690a9d235459a6127da3603083a3#diff-26827c8ca3f873e46a66c2dcbe661e958ca1f3459d9d4e9e1930641e5156441eR75 and the installed modules. The calculation of the counters is asynchronous (only with 3 RPC calls and 3 counters for each one) and sometimes `booking_count` is not load (that's why the link is not shown).

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa