### PR TITLE
[16.0][FIX] resource_booking: Avoid the error if a message is written from portal.

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -255,6 +255,12 @@ class ResourceBooking(models.Model):
         "mail.activity", "booking_id", string="Booking Activities"
     )
 
+    @api.model
+    def _mail_get_partner_fields(self):
+        """Avoid the error if a message is written from portal.
+        Define as author partner_id record from field."""
+        return ["partner_id"]
+
     @api.depends("partner_ids")
     def _compute_partner_id(self):
         for one in self:


### PR DESCRIPTION
Avoid the error if a message is written from portal.

Related to https://github.com/OCA/calendar/commit/8528dc74e3fa23ee2b82806f28745ceaee2dba18

Example use case:

- Create a resource booking with several Attendees
- Use the Share link
- Write a message

An error is displayed

```
File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 2093, in message_post
    self._notify_thread(new_message, msg_values, **notif_kwargs)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 2471, in _notify_thread
    self._notify_thread_by_email(message, recipients_data, msg_vals=msg_vals, **kwargs)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 2557, in _notify_thread_by_email
    recipients_groups_data = self._notify_get_recipients_classify(partners_data, model_name, msg_vals=msg_vals)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 2957, in _notify_get_recipients_classify
    groups = self._notify_get_recipients_groups(msg_vals=local_msg_vals)
  File "/opt/odoo/auto/addons/portal/models/mail_thread.py", line 33, in _notify_get_recipients_groups
    local_msg_vals['pid'] = customer.id
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 5092, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: res.partner(X, Y)
```

Please @pedrobaeza and @carolinafernandez-tecnativa can you review it?

@Tecnativa TT41745