### PR TITLE
[16.0][IMP] resource_booking: Add support for mail_note subtype by default

### DIFF
--- a/resource_booking/models/calendar_event.py
+++ b/resource_booking/models/calendar_event.py
@@ -52,13 +52,32 @@ class CalendarEvent(models.Model):
         rescheduled._validate_booking_modifications()
         return result
 
+    def _notify_thread(self, message, msg_vals=False, **kwargs):
+        """If we are creating the calendar event from the resource booking
+        (detected from the resource_booking_event context key), we need to
+        inject the standard mail context `mail_notify_author` to super to get
+        the own author notified when someone books a reservation, but only
+        in the case that the mail is being sent to them, as if not the author
+        may receive one copy per each of the attendees. This happens only when
+        the the subtype not is enabled by default in the instance.
+        """
+        if self.env.context.get("resource_booking_event") and msg_vals.get(
+            "author_id"
+        ) in msg_vals.get("partner_ids", []):
+            self = self.with_context(mail_notify_author=True)
+        return super()._notify_thread(message=message, msg_vals=msg_vals, **kwargs)
+
     @api.model_create_multi
     def create(self, vals_list):
         """Transfer resource booking to _attendees_values by context.
 
         We need to serialize the creation in that case.
-        mail_notify_author key from context is necessary to force the notification
-        to be sent to author.
+        resource_booking_event custom key from context is necessary.
+        We cannot use mail_notify_author key in the context because if the mail_note
+        subtype is set by default, the email of each attendee would be sent also to
+        the author (example: a meeting with 2 attendees would send 2 emails but
+        each of them would be sent to the partner of the attendee + author of
+        the email).
         """
         vals_list2 = []
         records = self.env["calendar.event"]
@@ -68,7 +87,7 @@ class CalendarEvent(models.Model):
                     CalendarEvent,
                     self.with_context(
                         resource_booking_ids=vals["resource_booking_ids"],
-                        mail_notify_author=True,
+                        resource_booking_event=True,
                     ),
                 ).create(vals)
             else:


### PR DESCRIPTION
Add support for mail_note subtype by default

If the default mail_note subtype is defined, when generating the calendar.event is generated and emails are sent to attendees, the mail_notify_author because each email would also be sent to the author (the event organizer).

Now it is changed to use a specific context and only send the email to the author if it is the the recipient of the email (the email of their attendance to the event).

Related to https://github.com/OCA/calendar/commit/575d2aa6d24d26ead89995d96e9709cdd5d9975a

@Tecnativa TT49045