### PR TITLE
[16.0][FIX] resource_booking: Change combination_id mandatory when autoassign is false

### DIFF
--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -832,7 +832,7 @@ class BackendCaseMisc(BackendCaseBase):
         rb_f.start = "2021-03-01 09:30:00"
         rb_f.duration = 0.5
         rb_f.partner_ids.add(self.partner.copy())
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValidationError):
             rb_f.save()
 
     def test_resource_is_available(self):

--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -153,7 +153,7 @@
                                 <field
                                     name="combination_id"
                                     class="oe_inline"
-                                    attrs="{'required': [('start', '!=', False)], 'readonly': [('combination_auto_assign', '=', True)]}"
+                                    attrs="{'required': [('combination_auto_assign', '=', False)], 'readonly': [('combination_auto_assign', '=', True)]}"
                                 />
                             </div>
                             <field name="categ_ids" widget="many2many_tags" />


### PR DESCRIPTION
- Change combination_id mandatory when autoassgin is false.
- Previously it was required when date is set but it is not taking into account if we share link and tried to book, user get an internal error server if combination_id is not set.

![image](https://github.com/OCA/calendar/assets/143796894/67847762-4da2-4724-9c88-fb5e0dbbb878)

@Tecnativa
@pedrobaeza @victoralmau 