### PR TITLE
[12.0][FIX] resource_booking: avoid unexpected keyword argument error

### DIFF
--- a/resource_booking/models/calendar_event.py
+++ b/resource_booking/models/calendar_event.py
@@ -36,10 +36,10 @@ class CalendarEvent(models.Model):
                 % "\n- ".join(frozen.mapped("display_name"))
             )
 
-    def unlink(self):
+    def unlink(self, can_be_deleted=True):
         """Check you're allowed to unschedule it."""
         self._validate_booking_modifications()
-        return super().unlink()
+        return super().unlink(can_be_deleted=can_be_deleted)
 
     def write(self, vals):
         """Check you're allowed to reschedule it."""


### PR DESCRIPTION
Missing argument in unlink method.

This is fixed in upper versions.