### PR TITLE
[16.0][IMP] resource_booking: get_intervals

### DIFF
--- a/resource_booking/__manifest__.py
+++ b/resource_booking/__manifest__.py
@@ -11,7 +11,7 @@
     "category": "Appointments",
     "website": "https://github.com/OCA/calendar",
     "author": "Tecnativa, Odoo Community Association (OCA)",
-    "maintainers": ["pedrobaeza", "ows-cloud"],
+    "maintainers": ["pedrobaeza", "norlinhenrik"],
     "license": "AGPL-3",
     "application": True,
     "installable": True,

--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -624,7 +624,7 @@ class ResourceBooking(models.Model):
                 test_start += slot_duration
         return result
 
-    def _get_intervals(self, start_dt, end_dt, combination=None):
+    def _get_intervals(self, start_dt, end_dt, combination=None, type=None):
         """Get available intervals for this booking,
         based on the calendar of the booking type
         and the calendar(s) of the relevant resource combination(s)."""
@@ -638,10 +638,11 @@ class ResourceBooking(models.Model):
             analyzing_booking=booking_id, exclude_public_holidays=True
         )
         # RBT calendar uses no resources to restrict bookings
-        if booking.type_id:
-            result = booking.type_id.resource_calendar_id._work_intervals_batch(
-                start_dt, end_dt
-            )[False]
+        if not type:
+            type = booking.type_id
+        if type and len(type) == 1:
+            r = type.resource_calendar_id._work_intervals_batch(start_dt, end_dt)[False]
+            result = r
         else:
             result = Intervals([])
         # Restrict with the chosen combination, or to at least one of the

--- a/resource_booking/models/resource_booking_combination.py
+++ b/resource_booking/models/resource_booking_combination.py
@@ -87,7 +87,7 @@ class ResourceBookingCombination(models.Model):
                 if not combination_intervals:
                     break  # Can't restrict more
                 calendar = combination.forced_calendar_id or res.calendar_id
-                # combination_intervals &= calendar._work_intervals(start_dt, end_dt, res)
+                # Get available intervals (see resource_calendar.py)
                 combination_intervals &= calendar._work_intervals_batch(
                     start_dt, end_dt, res
                 )[res.id]


### PR DESCRIPTION
Current workflow: Create a booking with a booking type, then check availablility.

Needed workflow: Check availability for a booking type without creating a booking.

_get_intervals() has a new input argument:

- start_dt
- end_dt
- combination=None
- **type=None**

---

2nd commit: maintainers. Shall I squash the commits?