### PR TITLE
[16.0][IMP] resource_booking: combination_id as filter on calendar view.

### DIFF
--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -18,7 +18,7 @@
                 <field name="name" invisible="True" />
                 <field name="partner_ids" widget="many2many_tags" />
                 <field name="type_id" />
-                <field name="combination_id" />
+                <field name="combination_id" filters="1" />
                 <field name="description" />
             </calendar>
         </field>


### PR DESCRIPTION
Good morning, I would like to add this contribution to the resource_booking as I believe it is quite useful. The modification would allow filtering directly in the calendar view by the combination of resources, adding the `combination_id` field, similar to how the calendar addon works with contacts.

![image](https://github.com/user-attachments/assets/6cd543c1-6726-41e1-95c6-4577cbb33d81)
