### PR TITLE
[16.0] [IMP] resource_booking: handle partner_ids (booking attendees) safely

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -431,7 +431,7 @@ class ResourceBooking(models.Model):
             location=self.location,
             videocall_location=self.videocall_location,
             name=self.name
-            or self._get_name_formatted(self.partner_ids[0], self.type_id),
+            or self._get_name_formatted(self.partner_ids[:1], self.type_id),
             partner_ids=[
                 (4, partner.id, 0) for partner in self.partner_ids | resource_partners
             ],
@@ -696,7 +696,7 @@ class ResourceBooking(models.Model):
             elif not record.name:
                 # Automatic name for backend users
                 name = self._get_name_formatted(
-                    record.partner_ids[0], record.type_id, record.meeting_id
+                    record.partner_ids[:1], record.type_id, record.meeting_id
                 )
             new.append((id_, name))
         return new


### PR DESCRIPTION
### 📝 Description

This PR enhances the `resource_booking` module by introducing a safeguard against potential issues arising from empty `partner_ids` when managing booking attendees.

#### 🛠️ Problem

In scenarios where `partner_ids` is empty or undefined, the system could encounter unexpected behaviors or errors during attendee processing.

#### ✅ Solution

~~Implemented a check to ensure that `partner_ids` is properly initialized and handled, preventing potential exceptions and ensuring consistent behavior.~~
Following suggestion from reviewers we just use `partner_ids[:1]` instead.

#### 🔍 Impact

- Enhances the robustness of the booking attendee management process.
- Prevents potential errors related to empty `partner_ids`.
- Improves overall system stability and user experience.

#### 📎 Related Issues

N/A

More context: OCA/e-commerce#1048
@BinhexTeam