### PR TITLE
[17.0][IMP] resource_booking: Fine-tuning after migration to 17

### DIFF
--- a/resource_booking/__init__.py
+++ b/resource_booking/__init__.py
@@ -1,3 +1,4 @@
 from . import models
 from . import controllers
+from . import wizard
 from .hooks import uninstall_hook

--- a/resource_booking/__manifest__.py
+++ b/resource_booking/__manifest__.py
@@ -35,6 +35,7 @@
         "security/resource_booking_security.xml",
         "security/ir.model.access.csv",
         "templates/portal.xml",
+        "wizard/mail_activity_schedule_views.xml",
         "views/calendar_event_views.xml",
         "views/mail_activity_views.xml",
         "views/res_partner_views.xml",

--- a/resource_booking/templates/portal.xml
+++ b/resource_booking/templates/portal.xml
@@ -42,9 +42,9 @@
                             </td>
                         </tr>
                     </thead>
-                    <thead class="thead-dark">
+                    <thead class="table-dark">
                         <tr>
-                            <th class="text-left">
+                            <th class="text-start">
                                 <a
                                     t-if="start > now"
                                     t-att-href="booking.get_portal_url(suffix='/schedule/%d/%d' % (start_previous.year, start_previous.month))"
@@ -59,7 +59,7 @@
                                 colspan="5"
                                 t-out="start.strftime('%B %Y')"
                             />
-                            <th class="text-right">
+                            <th class="text-end">
                                 <a
                                     t-att-href="booking.get_portal_url(suffix='/schedule/%d/%d' % (start_next.year, start_next.month))"
                                     class="btn btn-secondary"
@@ -290,7 +290,7 @@
                         <th>Type</th>
                         <th>Resources</th>
                         <th class="text-center">State</th>
-                        <th class="text-right">Date</th>
+                        <th class="text-end">Date</th>
                     </tr>
                 </thead>
                 <t t-foreach="bookings" t-as="booking">
@@ -311,11 +311,11 @@
                         </td>
                         <td class="text-center">
                             <span
-                                class="badge badge-secondary"
+                                t-attf-class="badge rounded-pill #{'text-bg-success' if booking.state == 'confirmed' else 'text-bg-info'}"
                                 t-field="booking.state"
                             />
                         </td>
-                        <td class="text-right">
+                        <td class="text-end">
                             <span t-field="booking.start" />
                         </td>
                     </tr>
@@ -331,11 +331,11 @@
                     <span t-field="booking_sudo.display_name" />
                 </h5>
             </div>
-            <div class="col-md text-md-right">
-                <small class="text-right">State:</small>
+            <div class="col-md text-md-end">
+                <small class="text-end">State:</small>
                 <span
                     t-field="booking_sudo.state"
-                    class="badge badge-secondary"
+                    t-attf-class="badge rounded-pill #{'text-bg-success' if booking_sudo.state == 'confirmed' else 'text-bg-info'}"
                     title="Current state of this booking"
                 />
             </div>
@@ -566,7 +566,7 @@
     </template>
     <template id="resource_booking_portal_schedule" name="Resource Booking Scheduling">
         <t t-call="portal.portal_layout">
-            <t t-set="o_portal_fullwidth_alert" groups="project.group_project_user">
+            <t t-set="o_portal_fullwidth_alert" groups="resource_booking.group_user">
                 <t t-call="portal.portal_back_in_edit_mode">
                     <t
                         t-set="backend_url"

--- a/resource_booking/views/resource_booking_views.xml
+++ b/resource_booking/views/resource_booking_views.xml
@@ -91,7 +91,7 @@
                         string="Cancel"
                         type="object"
                         help="Unschedule this booking and archive it."
-                        invisible="not is_modifiable or state == 'canceled' or not meeting_id"
+                        invisible="not is_modifiable or state == 'canceled' or meeting_id"
                     />
                     <button
                         name="action_cancel"

--- a/resource_booking/wizard/__init__.py
+++ b/resource_booking/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_activity_schedule

--- a/resource_booking/wizard/mail_activity_schedule.py
+++ b/resource_booking/wizard/mail_activity_schedule.py
@@ -1,0 +1,17 @@
+from odoo import models
+from odoo.exceptions import UserError
+
+
+class MailActivitySchedule(models.TransientModel):
+    _inherit = "mail.activity.schedule"
+
+    def action_open_resource_booking(self):
+        self.ensure_one()
+        if self.is_batch_mode:
+            raise UserError(
+                self.env._(
+                    "Scheduling an activity using the booking "
+                    "is not possible on more than one record."
+                )
+            )
+        return self._action_schedule_activities().action_open_resource_booking()

--- a/resource_booking/wizard/mail_activity_schedule_views.xml
+++ b/resource_booking/wizard/mail_activity_schedule_views.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="mail_activity_schedule_view_form" model="ir.ui.view">
+        <field name="name">mail.activity.schedule.inherit.calendar</field>
+        <field name="model">mail.activity.schedule</field>
+        <field name="inherit_id" ref="mail.mail_activity_schedule_view_form" />
+        <!-- To make sure calendar.mail_activity_schedule_view_form, which contains the invisible attributes, is loaded first -->
+        <field name="priority" eval="999" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='date_deadline']" position="attributes">
+                <attribute
+                    name="invisible"
+                >activity_category in ['resource_booking','meeting']</attribute>
+            </xpath>
+            <xpath expr="//field[@name='activity_user_id']" position="attributes">
+                <attribute
+                    name="invisible"
+                >activity_category in ['resource_booking','meeting']</attribute>
+            </xpath>
+            <xpath
+                expr="//button[@name='action_schedule_activities']"
+                position="attributes"
+            >
+                <attribute
+                    name="invisible"
+                >activity_category in ['resource_booking','meeting'] or id</attribute>
+            </xpath>
+            <xpath expr="//field[@name='note']" position="attributes">
+                <attribute
+                    name="invisible"
+                >activity_category in ['resource_booking','meeting']</attribute>
+            </xpath>
+            <xpath
+                expr="//button[@name='action_schedule_activities']"
+                position="before"
+            >
+                <button
+                    string="Open Resource Booking"
+                    invisible="activity_category != 'resource_booking'"
+                    name="action_open_resource_booking"
+                    type="object"
+                    class="btn-primary"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Adapt the portal design to the new style and complete the migration to BS5.
- Add support for creating bookings from mail.activity.schedule; this model is used when a user creates an activity from the chatter or the activity view.
- Prevent displaying two buttons to cancel the booking.
- Change group from `project.group_project_user` to `resource_booking.group_user`; this module does not depend on `project`, so referencing that group is incorrect.


These changes are backported from the migration to version 18 https://github.com/OCA/calendar/pull/159

TT56053
https://github.com/Tecnativa @pedrobaeza @victoralmau @pilarvargas-tecnativa could you please review this?

Before
![image](https://github.com/user-attachments/assets/e6043824-e20b-4a18-939f-12d61882d1bf)

![image](https://github.com/user-attachments/assets/10af0d6e-d8fb-49dd-a33b-fa9a65a459c0)

![image](https://github.com/user-attachments/assets/727d97b7-fc5b-4f71-befb-02ff0d3d8bb2)

After

![image](https://github.com/user-attachments/assets/a6ba0452-b9fa-476d-9743-9926acc9cc29)

![image](https://github.com/user-attachments/assets/6a67ea34-b4c0-4465-b8fa-7fb18c8b95a1)

![image](https://github.com/user-attachments/assets/f387b683-56fe-4e0f-9b55-88ee4b10c0b6)
