### PR TITLE
[18.0][FIX] resource_booking: Change the close button of the availability alert to something more coherent

### DIFF
--- a/resource_booking/templates/portal.xml
+++ b/resource_booking/templates/portal.xml
@@ -551,6 +551,12 @@
         <div
             class="alert alert-danger alert-dismissible rounded-0 fade show d-print-none css_editable_mode_hidden"
         >
+            <button
+                type="button"
+                class="btn-close"
+                data-bs-dismiss="alert"
+                aria-label="Close"
+            />
             <div class="container">
                 <div t-ignore="true" class="text-center">
                     <strong>The chosen schedule is no longer available.</strong>
@@ -561,14 +567,6 @@
                     </t>
                 </div>
             </div>
-            <button
-                type="button"
-                class="close"
-                data-bs-dismiss="alert"
-                aria-label="Close"
-            >
-                &#215;
-            </button>
         </div>
     </template>
     <template id="resource_booking_portal_schedule" name="Resource Booking Scheduling">


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/calendar/pull/161

Change the close button of the availability alert to something more coherent (related to https://github.com/OCA/e-commerce/pull/1065#pullrequestreview-2961737057)

**Before**
![antes](https://github.com/user-attachments/assets/d45d9d82-8131-40e5-a9ee-2362e4b0a6f7)

**After**
![despues](https://github.com/user-attachments/assets/9365bde1-9dc5-4a50-9f6a-88805d484b64)

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT51971