### PR TITLE
[18.0][FIX] resource_booking: avoid importing Form outside of tests

### DIFF
--- a/resource_booking/controllers/portal.py
+++ b/resource_booking/controllers/portal.py
@@ -8,7 +8,6 @@ from dateutil.parser import isoparse
 
 from odoo.exceptions import AccessError, MissingError, ValidationError
 from odoo.http import request, route
-from odoo.tests import Form
 
 from odoo.addons.portal.controllers import portal
 
@@ -131,8 +130,7 @@ class CustomerPortal(portal.CustomerPortal):
         when_tz_aware = isoparse(when)
         when_naive = datetime.utcfromtimestamp(when_tz_aware.timestamp())
         try:
-            with Form(booking_sudo) as booking_form:
-                booking_form.start = when_naive
+            booking_sudo.start = when_naive
         except ValidationError as error:
             url = booking_sudo.get_portal_url(
                 suffix=f"/schedule/{when_tz_aware:%Y/%m}",


### PR DESCRIPTION
Since this commit https://github.com/odoo/odoo/commit/1f3a15a7d1f527ab05937810b6a1fb60c22ff455, when Odoo starts without tests enabled and the `Form` class is used in business code, an error appears in the log. This commit removes the usage of `Form`, which is not necessary anymore because no onchange methods depend on the start field, all fields are computed now.

Fixes https://github.com/OCA/calendar/issues/163

cc: @pedrobaeza @ByteMeAsap