### PR TITLE
[18.0][FIX] resource_booking: add display_name in test

### DIFF
--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -793,6 +793,7 @@ class BackendCaseMisc(BackendCaseBase):
                 "lang": None,
                 "partner_id": rb.partner_ids.id,
                 "name": "some customer",
+                "display_name": "some customer",
                 "reason": "Attendees",
             },
         )


### PR DESCRIPTION
Odoo added this new key in commit
https://github.com/odoo/odoo/commit/c840bdedb99320360b31dc3674022ea01800832a.

To prevent the test from failing, we updated the data accordingly.

<img width="1313" height="332" alt="image" src="https://github.com/user-attachments/assets/e5eb5dbc-d7fc-457d-a395-77a27efd1b1a" />

https://github.com/OCA/calendar/actions/runs/17429589563/job/49484640129#step:8:449

@Tecnativa @pedrobaeza @victoralmau could you please review this?