### PR TITLE
[17.0][FIX] resource_booking: use sudo() for booking searches to avoid permission issues

### DIFF
--- a/resource_booking/models/resource_calendar.py
+++ b/resource_booking/models/resource_calendar.py
@@ -19,14 +19,18 @@ class ResourceCalendar(models.Model):
     @api.constrains("attendance_ids", "global_leave_ids", "leave_ids", "tz")
     def _check_bookings_scheduling(self):
         """Scheduled bookings must have no conflicts."""
-        bookings = self.env["resource.booking"].search(
-            [
-                ("state", "=", "confirmed"),
-                ("stop", ">=", fields.Datetime.now()),
-                "|",
-                ("combination_id.forced_calendar_id", "in", self.ids),
-                ("combination_id.resource_ids.calendar_id", "in", self.ids),
-            ]
+        bookings = (
+            self.env["resource.booking"]
+            .sudo()
+            .search(
+                [
+                    ("state", "=", "confirmed"),
+                    ("stop", ">=", fields.Datetime.now()),
+                    "|",
+                    ("combination_id.forced_calendar_id", "in", self.ids),
+                    ("combination_id.resource_ids.calendar_id", "in", self.ids),
+                ]
+            )
         )
         return bookings._check_scheduling()
 

--- a/resource_booking/models/resource_resource.py
+++ b/resource_booking/models/resource_resource.py
@@ -12,8 +12,10 @@ class ResourceResource(models.Model):
     @api.constrains("calendar_id", "resource_type", "tz", "user_id")
     def _check_bookings_scheduling(self):
         """Scheduled bookings must have no conflicts."""
-        bookings = self.env["resource.booking"].search(
-            [("combination_id.resource_ids", "in", self.ids)]
+        bookings = (
+            self.env["resource.booking"]
+            .sudo()
+            .search([("combination_id.resource_ids", "in", self.ids)])
         )
         return bookings._check_scheduling()
 


### PR DESCRIPTION

Steps to reproduce:

- Install `resource_booking` and `hr` modules.
- Create a user with "Employee Officer: Manage all employees" rights (without the "Resource Booking User" role).
- Go to Employees and create a record.


<img width="584" height="215" alt="image" src="https://github.com/user-attachments/assets/e1bb6ecc-8916-45e0-823e-836a8b57f38a" />

<img width="594" height="321" alt="image" src="https://github.com/user-attachments/assets/d17331e9-d016-40fe-9b47-a03228c5e9b9" />

Since `hr.employee` inherits from `resource.resource`, the constraint `_check_bookings_scheduling` is executed.
When the search is performed, an error is raised due to missing permissions.

This commit fixes the issue by using `sudo()` for booking searches.


@Tecnativa @pedrobaeza could you please review this?