### PR TITLE
[18.0][FIX] resource_booking: display all slots in the same time zone correctly

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -7,6 +7,7 @@ import calendar
 from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
+from pytz import timezone
 
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
@@ -603,7 +604,8 @@ class ResourceBooking(models.Model):
             or booking.combination_id
             or booking.mapped("type_id.combination_rel_ids.combination_id")
         ).with_context(analyzing_booking=booking_id)
-        result &= combinations._get_intervals(start_dt, end_dt)
+        tz = timezone(self.type_id.resource_calendar_id.tz)
+        result &= combinations._get_intervals(start_dt, end_dt, tz)
         return result
 
     def _sync_booking_activities_date(self):

--- a/resource_booking/models/resource_booking_combination.py
+++ b/resource_booking/models/resource_booking_combination.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models
 
+from odoo.addons.hr_work_entry_contract.models.hr_work_intervals import WorkIntervals
 from odoo.addons.resource.models.utils import Intervals
 
 
@@ -80,7 +81,7 @@ class ResourceBookingCombination(models.Model):
         bookings = self.mapped("booking_ids")
         return bookings._check_scheduling()
 
-    def _get_intervals(self, start_dt, end_dt):
+    def _get_intervals(self, start_dt, end_dt, tz):
         """Get available intervals for this booking combination."""
         base = Intervals([(start_dt, end_dt, self)])
         result = Intervals([])
@@ -93,9 +94,19 @@ class ResourceBookingCombination(models.Model):
                 calendar = combination.forced_calendar_id or res.calendar_id
                 # combination_intervals &= calendar._work_intervals(start_dt,
                 # end_dt, res)
-                combination_intervals &= calendar._work_intervals_batch(
+                combination_intervals_in_tz = calendar._work_intervals_batch(
                     start_dt, end_dt, res
                 )[res.id]
+                # Convert to the specified time zone if needed
+                # to display the intervals correctly in the same time zone.
+                if calendar.tz != tz.zone:
+                    new_intervals = []
+                    for interval in combination_intervals_in_tz:
+                        start = interval[0].astimezone(tz)
+                        end = interval[1].astimezone(tz)
+                        new_intervals.append((start, end, interval[2]))
+                    combination_intervals_in_tz = WorkIntervals(new_intervals)
+                combination_intervals &= combination_intervals_in_tz
             result |= combination_intervals
         return result
 

--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -934,6 +934,50 @@ class BackendCaseMisc(BackendCaseBase):
             )
         )
 
+    def test_resource_two_timezone(self):
+        """
+        Test that resource booking works correctly with two different time zones.
+        - The resource calendar is set to the America/Guayaquil time zone
+            and starts at 06:00.
+        - The booking type has a calendar in the Europe/Madrid time zone
+            and starts at 09:00.
+        The slots should be returned in the same time zone as the booking type.
+        The first slot should start at 06:00 in America/Guayaquil,
+        which corresponds to 12:00 in Europe/Madrid.
+        """
+        calendar_friday = self.r_calendars[3]
+        rbc_friday = self.rbcs[3]
+        rbc_friday.resource_ids.write({"tz": "America/Guayaquil"})
+        calendar_friday.write({"tz": "America/Guayaquil"})
+        calendar_friday.attendance_ids.write({"hour_from": 6, "hour_to": 15})
+        calendar_meeting = calendar_friday.copy(
+            {"name": "Calendar Meeting", "tz": "Europe/Madrid"}
+        )
+        calendar_meeting.attendance_ids.write({"hour_from": 9, "hour_to": 14})
+        self.rbt.write(
+            {
+                "resource_calendar_id": calendar_meeting.id,
+                "modifications_deadline": 2,
+            }
+        )
+        resource_booking = self.env["resource.booking"].create(
+            {
+                "partner_ids": [(4, self.partner.id)],
+                "duration": 2,
+                "type_id": self.rbt.id,
+                "combination_id": rbc_friday.id,
+                "combination_auto_assign": False,
+            }
+        )
+        response = resource_booking._get_calendar_context()
+        for slots in response["slots"].values():
+            # The first slot should start at 06:00 in America/Guayaquil.
+            # In Europe/Madrid, it should be 12:00.
+            self.assertEqual(slots[0].strftime("%H:%M:%S"), "12:00:00")
+            # Check that all slots are in the expected time zone.
+            for slot in slots:
+                self.assertEqual(slot.tzinfo.zone, "Europe/Madrid")
+
 
 class TestMailActivity(BaseCommon):
     @classmethod


### PR DESCRIPTION
When using a booking type with a resource calendar that has a different time zone than the resource itself, the slots are returned with mixed time zones. This commit normalizes the behavior and ensures that slots are always returned in the time zone of the booking type.

Steps to reproduce:

Create a resource with the time zone America/Guayaquil, and a calendar that starts from 06:00 to 15:00.

Create a resource booking type with a new calendar that starts from 09:00 to 16:00, and set the time zone to Europe/Madrid.

Before this commit, the slot displayed in the portal was 06:00, but it should have been 12:00. After this commit, the slot is displayed in the correct time zone (Madrid) at 12:00.

Note: The 06:00 in America/Guayaquil corresponds to 12:00 in Madrid standard time, not during daylight saving time. The tests use a freeze date in February.


Forward-port of https://github.com/OCA/calendar/pull/168

@Tecnativa @pedrobaeza @victoralmau could you please review this?