### PR TITLE
[18.0][FIX] resource_booking: correct resource parameter in availability check

### DIFF
--- a/resource_booking/models/resource_resource.py
+++ b/resource_booking/models/resource_resource.py
@@ -29,7 +29,7 @@ class ResourceResource(models.Model):
         # available here, we set the value to -1.
         result = self.calendar_id.with_context(
             analyzing_booking=-1
-        )._work_intervals_batch(
-            start_dt, end_dt, resources=[self], domain=domain, tz=tz
-        )[self.id]
+        )._work_intervals_batch(start_dt, end_dt, resources=self, domain=domain, tz=tz)[
+            self.id
+        ]
         return _availability_is_fitting(result, start_dt, end_dt)


### PR DESCRIPTION
The resources parameter must be a recordset, not a list. Before this commit, this was not a problem, but in this commit https://github.com/odoo/odoo/commit/79a559c9741410ad861c107e395b2fc486da95e8 , Odoo began expecting a recordset to call the function _get_calendar_att. This change was introduced during the migration to V15 in this commit https://github.com/OCA/calendar/commit/b7a6f5b2da40b8f3672966d5d93829f92ee8e7d8 , so we updated the parameter to pass it as a record.

@Tecnativa @pedrobaeza @victoralmau could you please review this?