### PR TITLE
[18.0][FIX] resource_booking: create the meeting with same tz as when sched…

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -420,6 +420,11 @@ class ResourceBooking(models.Model):
                         meeting = meeting.with_context(from_ui=True)
                     meeting.write(meeting_vals)
                 else:
+                    # Force the tz just in the creation
+                    # as it cannot be changed on write
+                    event_tz = one.type_id.resource_calendar_id.tz or False
+                    if event_tz:
+                        meeting_vals["event_tz"] = event_tz
                     to_create.append(meeting_vals)
             else:
                 to_delete |= one.meeting_id


### PR DESCRIPTION
…uling 

When scheduling from the portal the tz is retrieved from the calendar linked to the booking type. But when creating the calendar event, the tz is taken from the Organizer wich could be different so the event is created with the datetime choosed in the portal but a different tz.

Also the change is done just for the creation because the event_tz field is blocked for recurrence update (even without it). More info in: https://github.com/odoo/odoo/blob/b3bc5615598ae12e7fda8c735897566b8f9f50d7/addons/calendar/models/calendar_event.py#L703

@Tecnativa