### PR TITLE
[18.0][IMP] calendar_public_holiday: Improve hooks for renaming table in the state_ids field (Many2many)

### DIFF
--- a/calendar_public_holiday/hooks.py
+++ b/calendar_public_holiday/hooks.py
@@ -35,6 +35,13 @@ def migrate_rename_model_hr_holidays_public_line(env):
     openupgrade.rename_models(env.cr, model_renames)
     tables_renames = [("hr_holidays_public_line", "calendar_public_holiday_line")]
     openupgrade.rename_tables(env.cr, tables_renames)
+    # Rename Many2many relation
+    tables_renames = [("hr_holiday_public_state_rel", "public_holiday_state_rel")]
+    openupgrade.rename_tables(env.cr, tables_renames)
+    column_renames = {
+        "public_holiday_state_rel": [("line_id", "public_holiday_line_id")],
+    }
+    openupgrade.rename_columns(env.cr, column_renames)
 
 
 def migrate_rename_model_hr_holidays_public(env):


### PR DESCRIPTION
Improve hooks for renaming table in the `state_ids` field (Many2many): https://github.com/OCA/hr-holidays/blob/d514ab87a5fe8f8c6a5253491d2b9d7618017139/hr_holidays_public/models/hr_holidays_public.py#L141

Please @pedrobaeza can you review it?

@Tecnativa TT60688