### PR TITLE
[17.0][FIX] resource_booking: access error on normal calendar

### DIFF
--- a/resource_booking/tests/test_backend.py
+++ b/resource_booking/tests/test_backend.py
@@ -35,6 +35,19 @@ class BackendCaseBase(TransactionCase):
 @freeze_time("2021-02-26 09:00:00", tick=True)  # Last Friday of February
 class BackendCaseMisc(BackendCaseBase):
     @users("plain")
+    def test_plain_user_calendar_event_form(self):
+        event_form = Form(
+            self.env["calendar.event"].with_context(
+                default_partner_ids=self.env.user.partner_id.ids,
+                default_start="2023-01-01 00:00:00",
+                default_stop="2023-01-01 01:00:00",
+            )
+        )
+        event_form.name = "Test calendar event"
+        event = event_form.save()
+        self.assertEqual(event.name, "Test calendar event")
+
+    @users("plain")
     @mute_logger("odoo.models.unlink")
     def test_plain_user_calendar_event(self):
         """Check that a simple user is able to handle manual calendar events."""

--- a/resource_booking/views/calendar_event_views.xml
+++ b/resource_booking/views/calendar_event_views.xml
@@ -8,7 +8,11 @@
         <field name="inherit_id" ref="calendar.view_calendar_event_form" />
         <field name="arch" type="xml">
             <form position="inside">
-                <field name="resource_booking_ids" invisible="1" />
+                <field
+                    name="resource_booking_ids"
+                    invisible="1"
+                    groups="resource_booking.group_user"
+                />
             </form>
         </field>
     </record>


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/calendar/pull/211

When a user had no resource_booking permissions and opened a calendar event linked to a resource booking, he got an unnecessary access error.

**Before**:
![ejemplo](https://github.com/user-attachments/assets/9f8d5454-2fdc-43f3-89f8-5e475ada8168)

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa