### PR TITLE
[18.0][FIX] resource_booking: Add description to meeting values only when the field is set

### DIFF
--- a/resource_booking/models/resource_booking.py
+++ b/resource_booking/models/resource_booking.py
@@ -375,10 +375,9 @@ class ResourceBooking(models.Model):
         resource_partners = self.combination_id.resource_ids.filtered(
             lambda res: res.resource_type == "user"
         ).mapped("user_id.partner_id")
-        return dict(
+        meeting_vals = dict(
             alarm_ids=[(6, 0, self.type_id.alarm_ids.ids)],
             categ_ids=[(6, 0, self.categ_ids.ids)],
-            description=self.type_id.requester_advice,
             duration=self.duration,
             location=self.location,
             videocall_location=self.videocall_location,
@@ -396,6 +395,9 @@ class ResourceBooking(models.Model):
             res_model_id=False,
             res_id=False,
         )
+        if self.type_id.requester_advice:
+            meeting_vals["description"] = self.type_id.requester_advice
+        return meeting_vals
 
     def _sync_meeting(self):
         """Lazy-create or destroy calendar.event."""


### PR DESCRIPTION
For a curious reason, the `test_resource_booking_schedule_unschedule` test fails after this PR: https://github.com/odoo/odoo/pull/223875 The `requester_advice` field is of type `Text`, but in `calendar.event` the `description` field is `HTML`. I tried changing the field type to HTML, but the error still occurs, so another approach is to only pass the field when it is filled.

See log error in https://github.com/OCA/calendar/pull/213
@Tecnativa @pedrobaeza @victoralmau could you please review this?