### PR TITLE
[FIX] checklog-odoo.cfg: ignore Killing chrome descendants-or-self warning

### DIFF
--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,4 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING .* Killing chrome descendants-or-self .*


### PR DESCRIPTION
## Summary

Add an ignore pattern to `checklog-odoo.cfg` so the well-known chrome-zombie WARNING from Odoo's HttpCase tour cleanup does not promote passing test runs to CI failures.

The pattern is **verbatim** the one already in use across the OCA org:

| Repo | Commit | Author | Date |
|---|---|---|---|
| OCA/web | [c7fbf2d](https://github.com/OCA/web/commit/c7fbf2d) | Stefan Rijnhart | 2026-04-13 |
| OCA/server-ux | [ca7dd94](https://github.com/OCA/server-ux/commit/ca7dd94) | Stefan Rijnhart | 2026-04-13 |
| OCA/social | [b672f28](https://github.com/OCA/social/commit/b672f28) | Luis Rodriguez | 2026-04-13 |
| OCA/website | [dce9ae7](https://github.com/OCA/website/commit/dce9ae7) | Enric Tobella | 2026-04-15 |

Plus ~16 other OCA repos with the same regex in their `checklog-odoo.cfg` (helpdesk, pos, dms, mail, reporting-engine, l10n-brazil, e-commerce, connector-telephony, account-analytic, contract, edi-framework, oca-custom, stock-weighing, route-planning, rma, …).

## Why this matters for `OCA/calendar`

The chrome-zombie WARNING (introduced in [odoo/odoo@d22e0b4e](https://github.com/odoo/odoo/commit/d22e0b4e181de0940810b0f0a760bcfe288042a7)) is emitted by Odoo's HttpCase test framework when headless-chrome renderer subprocesses don't exit cleanly after a tour test. The test outcomes themselves are reported on a separate line.

`resource_booking` (currently on 18.0, in the process of being migrated to 19.0 in #217) has multiple tour tests (`test_portal_no_bookings`, `test_portal_list_with_bookings`, `test_portal_scheduling_conflict`) that hit this every run. Without this ignore pattern, the CI failure log looks like:

```
2026-05-16 09:00:07,221 306 WARNING odoo odoo.addons.resource_booking.tests.test_portal.PortalCase.test_portal_list_with_bookings: Killing chrome descendants-or-self of 323: 5 remaining
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
...
2026-05-16 ... INFO odoo odoo.tests.result: 0 failed, 0 error(s) of 49 tests when loading database 'odoo'
...
errors that caused failure (2):
... WARNING ... Killing chrome descendants-or-self of 323: 5 remaining
... WARNING ... Killing chrome descendants-or-self of 462: 5 remaining
Error: Errors detected in log.
```

All 49 tests pass. The only "errors that caused failure" are the two chrome WARNINGs. With this PR's ignore pattern, those WARNINGs land in the "errors that did not cause failure" bucket (as they do in OCA/web, OCA/server-ux, OCA/social et al.) and CI goes green.

## Verification

Cherry-picked the same one-line change onto #217's branch and re-ran CI: all 7 checks pass (`test with Odoo`, `test with OCB`, `pre-commit`, `codecov/patch`, `codecov/project`, `runboat/build`, `Detect unreleased dependencies`). Plan to drop the equivalent commit from #217 once this PR merges so the MIG stays scope-clean.

## Test plan

- [x] CI green here (this PR only changes the config; no tests run on a single-line cfg change)
- [ ] Once merged, #217 (and any future 19.0 PR with tour tests) goes green without bundling this fix

## Convention used

Same regex format as OCA/web's `checklog-odoo.cfg`: `WARNING .* Killing chrome descendants-or-self .*` (space-before-`.*`, permissive trailer).