### PR TITLE
[18.0][FIX] resource_booking: portal home and listing tolerate users without read access

### DIFF
--- a/resource_booking/controllers/portal.py
+++ b/resource_booking/controllers/portal.py
@@ -53,23 +53,27 @@ class CustomerPortal(portal.CustomerPortal):
         website=True,
     )
     def portal_my_bookings(self, page=1, **kwargs):
-        """List bookings that I can access."""
+        """List bookings that I can access.
+
+        Users without read access on resource.booking get an empty list
+        rendered through the same code path — same pager shape, same
+        template — so the page degrades gracefully instead of raising
+        AccessError on the unguarded search_count.
+        """
         Booking = request.env["resource.booking"].with_context(using_portal=True)
         values = self._prepare_portal_layout_values()
-        # A portal user with no read access on resource.booking should land
-        # on an empty list, not on a hard AccessError.
-        if not Booking.has_access("read"):
-            values.update({"bookings": Booking, "pager": {}, "page_name": "bookings"})
-            return request.render("resource_booking.portal_my_bookings", values)
-        booking_count = Booking.search_count([])
+        has_access = Booking.has_access("read")
+        booking_count = Booking.search_count([]) if has_access else 0
         pager = portal.pager(
             url="/my/bookings",
             total=booking_count,
             page=page,
             step=self._items_per_page,
         )
-        bookings = Booking.search(
-            [], limit=self._items_per_page, offset=pager["offset"]
+        bookings = (
+            Booking.search([], limit=self._items_per_page, offset=pager["offset"])
+            if booking_count
+            else Booking
         )
         request.session["my_bookings_history"] = bookings.ids
         values.update({"bookings": bookings, "pager": pager, "page_name": "bookings"})

--- a/resource_booking/controllers/portal.py
+++ b/resource_booking/controllers/portal.py
@@ -25,8 +25,13 @@ class CustomerPortal(portal.CustomerPortal):
     def _prepare_home_portal_values(self, counters):
         """Compute values for multi-booking portal views."""
         values = super()._prepare_home_portal_values(counters)
+        Booking = request.env["resource.booking"]
         if "booking_count" in counters:
-            booking_count = request.env["resource.booking"].search_count([])
+            # Portal users without read access on resource.booking would have
+            # raised an AccessError here, breaking the whole /my landing page.
+            booking_count = (
+                Booking.search_count([]) if Booking.has_access("read") else 0
+            )
             values.update({"booking_count": booking_count})
         return values
 
@@ -51,6 +56,11 @@ class CustomerPortal(portal.CustomerPortal):
         """List bookings that I can access."""
         Booking = request.env["resource.booking"].with_context(using_portal=True)
         values = self._prepare_portal_layout_values()
+        # A portal user with no read access on resource.booking should land
+        # on an empty list, not on a hard AccessError.
+        if not Booking.has_access("read"):
+            values.update({"bookings": Booking, "pager": {}, "page_name": "bookings"})
+            return request.render("resource_booking.portal_my_bookings", values)
         booking_count = Booking.search_count([])
         pager = portal.pager(
             url="/my/bookings",

--- a/resource_booking/tests/test_portal.py
+++ b/resource_booking/tests/test_portal.py
@@ -283,9 +283,14 @@ class PortalCase(HttpCase):
         self.authenticate("plain_internal", "plain_internal")
         response = self.url_open("/my", timeout=10)
         self.assertEqual(response.status_code, 200)
-        # No traceback page; portal home rendered
-        self.assertNotIn("Traceback", response.text)
-        self.assertNotIn("AccessError", response.text)
+        # Positive marker: the standard portal-home CSS hook is present, so
+        # the layout actually rendered rather than degrading to an error page.
+        tree = fromstring(response.text)
+        self.assertTrue(
+            tree.cssselect(".o_portal_my_home, .o_portal_wrap"),
+            "Portal home wrapper element should render even without "
+            "resource.booking read access",
+        )
 
     def test_portal_my_bookings_no_access_renders_empty(self):
         """An internal user without booking read access lands on an empty list."""
@@ -302,5 +307,10 @@ class PortalCase(HttpCase):
         self.authenticate("plain_internal2", "plain_internal2")
         response = self.url_open("/my/bookings", timeout=10)
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn("Traceback", response.text)
-        self.assertNotIn("AccessError", response.text)
+        # Positive marker: the empty-state alert from the QWeb template
+        # confirms the bookings listing rendered with zero rows rather than
+        # falling through to an error page.
+        self.assertIn(
+            "There are currently no bookings for your account.",
+            response.text,
+        )

--- a/resource_booking/tests/test_portal.py
+++ b/resource_booking/tests/test_portal.py
@@ -260,3 +260,47 @@ class PortalCase(HttpCase):
         portal_url = link.get("href")
         portal_page = self._url_xml(portal_url)
         self.assertTrue(portal_page.cssselect(".oe_login_form"))
+
+    def test_portal_home_no_resource_booking_access(self):
+        """Internal users without resource_booking permissions can still view /my.
+
+        Portal users have read access via the dedicated ACL, but a plain
+        internal user (e.g. someone added by another website-facing module)
+        has no row in ir.model.access.csv for resource.booking, so the
+        unguarded search_count in _prepare_home_portal_values used to raise
+        AccessError and break the entire portal home page.
+        """
+        plain = new_test_user(
+            self.env,
+            login="plain_internal",
+            password="plain_internal",
+            groups="base.group_user",
+        )
+        self.assertFalse(
+            self.env["resource.booking"].with_user(plain).has_access("read"),
+            "test precondition: plain internal user must lack booking read",
+        )
+        self.authenticate("plain_internal", "plain_internal")
+        response = self.url_open("/my", timeout=10)
+        self.assertEqual(response.status_code, 200)
+        # No traceback page; portal home rendered
+        self.assertNotIn("Traceback", response.text)
+        self.assertNotIn("AccessError", response.text)
+
+    def test_portal_my_bookings_no_access_renders_empty(self):
+        """An internal user without booking read access lands on an empty list."""
+        plain = new_test_user(
+            self.env,
+            login="plain_internal2",
+            password="plain_internal2",
+            groups="base.group_user",
+        )
+        self.assertFalse(
+            self.env["resource.booking"].with_user(plain).has_access("read"),
+            "test precondition: plain internal user must lack booking read",
+        )
+        self.authenticate("plain_internal2", "plain_internal2")
+        response = self.url_open("/my/bookings", timeout=10)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Traceback", response.text)
+        self.assertNotIn("AccessError", response.text)


### PR DESCRIPTION
A user landing on `/my` that lacks `resource.booking` read access (e.g. an internal user not in `resource_booking.group_user`, or one added by another website-facing module) used to hit a hard `AccessError`:

- `_prepare_home_portal_values` called `search_count([])` unguarded, breaking the entire portal home page when `booking_count` was in `counters`.
- `portal_my_bookings` called `search_count([])` unguarded, breaking the `/my/bookings` listing for the same users.

Both paths now check `Booking.has_access("read")` and degrade gracefully (zero counter, empty list page). Portal users with the dedicated ACL row keep the existing behavior.

Distinct from [1c59c21](https://github.com/OCA/calendar/commit/1c59c21c7d59401144a322d23bb48849b036fa9d) which fixed the calendar-event form (different surface).

Adds 2 tests in `tests/test_portal.py`: `test_portal_home_no_resource_booking_access`, `test_portal_my_bookings_no_access_renders_empty`.

`/ocabot merge patch`