### PR TITLE
[19.0][FIX] resource_booking: keep booking timezone in invitation mails

### DIFF
--- a/resource_booking/models/__init__.py
+++ b/resource_booking/models/__init__.py
@@ -1,3 +1,4 @@
+from . import calendar_attendee
 from . import calendar_event
 from . import res_partner
 from . import resource_booking

--- a/resource_booking/models/calendar_attendee.py
+++ b/resource_booking/models/calendar_attendee.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Thierry Leblanc
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class CalendarAttendee(models.Model):
+    _inherit = "calendar.attendee"
+
+    def _compute_mail_tz(self):
+        """Autofix tz from related resource booking.
+
+        Any notification related to a resource.booking must be emitted in the
+        same TZ as the resource.booking. Otherwise it's confusing to the user.
+
+        In v18 this was done by overriding calendar.event.get_interval(), which
+        no longer exists in v19: the invitation template now resolves the
+        timezone from calendar.attendee.mail_tz.
+        """
+        res = super()._compute_mail_tz()
+        for attendee in self:
+            booking = attendee.event_id.sudo().resource_booking_ids
+            booking_tz = booking.type_id.resource_calendar_id.tz
+            if booking_tz:
+                attendee.mail_tz = booking_tz
+        return res

--- a/resource_booking/models/calendar_event.py
+++ b/resource_booking/models/calendar_event.py
@@ -76,16 +76,6 @@ class CalendarEvent(models.Model):
         records += super().create(vals_list2)
         return records
 
-    def get_interval(self, interval, tz=None):
-        """Autofix tz from related resource booking.
-
-        This function is called to render calendar.event notification mails.
-        Any notification related to a resource.booking must be emitted in the
-        same TZ as the resource.booking. Otherwise it's confusing to the user.
-        """
-        tz = self.resource_booking_ids.type_id.resource_calendar_id.tz or tz
-        return super().get_interval(interval=interval, tz=tz)
-
     def _attendees_values(self, partner_commands):
         """Autoconfirm resource attendees if preselected and hand-picked on RB.
 


### PR DESCRIPTION
Follow-up to #217 (merged this morning). Found while doing the functional review.

### Problem

`models/calendar_event.py` overrides `get_interval()`, whose docstring states that any
notification related to a booking must be emitted in the resource booking timezone.
That method no longer exists in `calendar/models/calendar_event.py` in 19.0 — the
invitation template now resolves the timezone from `calendar.attendee.mail_tz`, computed
as `partner_id.tz` only. The override is therefore never called, and its `super()` would
target a missing method. The 18.0 behaviour was lost during the migration, silently: no
error, no warning, no failing test.

Consequence: invitation e-mails for a booking are rendered with `tz=False` whenever the
attendee's partner has no timezone, so the time is printed in UTC — and since the template
guards the timezone label with `t-if="object.mail_tz"`, no timezone is shown at all.

This is not an edge case. Partners created by the public booking route
(`website_appointment_booking`) are created with name and e-mail only, so they never have
a timezone. A customer reading the mail body would arrive at the wrong hour, while the
attached `invitation.ics` is correct.

### Fix

Move the timezone forcing to `calendar.attendee._compute_mail_tz()`, which is where 19.0
resolves it, and drop the now-dead `get_interval()` override. `sudo()` is needed because
a public visitor has no read access on `resource.booking` (same precaution as
`calendar_event.py::_check_bookings_scheduling`).

### Tested on

Odoo 19.0 Community from source, Python 3.12, PostgreSQL 18. Booking type with an
availability calendar in `Europe/Brussels`, booked through the public route in a private
window, real SMTP, invitation read in a real mailbox.

- Before: mail body reads `11:00 AM`, with no timezone label.
- After: mail body reads `Thursday 13 August 2026 01:00 PM (Europe/Brussels)`, with the
  attendee's partner still having no timezone set.

@dnplkndll @pedrobaeza @carlos-lopez-tecnativa